### PR TITLE
Align RFCs, schemas, and docs with runtime behavior and extension mod…

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ MACP is intentionally split into a small set of RFCs because that makes the stan
 - **RFC-MACP-0006 Transport Bindings** defines standard transport bindings (gRPC, HTTP, WebSocket, Message Bus).
 - **RFC-MACP-0007 through RFC-MACP-0011** define the main-repository standard modes: Decision, Proposal, Task, Handoff, and Quorum.
 
-The main RFC repo standardizes only foundational coordination primitives. Domain workflows and fast-moving experiments should live in incubator or vendor repositories, not in this standards repo.
+The main RFC repo standardizes only foundational coordination primitives. Domain workflows and fast-moving experiments should live in incubator or vendor repositories, not in this standards repo. Runtimes may still ship additional implementation-defined modes, but those modes should not be presented as part of the five-mode standards-track set unless they are promoted into this repo and registry.
 
 ## Capability negotiation
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ This chapter uses the following terms:
 An identifiable computational entity that emits and receives MACP Envelopes.
 
 **Signal**  
-An ambient, non-binding message carrying informational updates. Signals MUST NOT create sessions, mutate session state, or produce binding outcomes.
+An ambient, non-binding message carrying informational updates. In the base protocol, Signals carry an empty `session_id` and an empty `mode`; if they need to correlate with a session, that reference belongs inside the payload. Signals MUST NOT create sessions, mutate session state, or produce binding outcomes.
 
 **Coordination Session**  
 A bounded coordination context created only by `SessionStart`, governed by a declared Mode and a monotonic lifecycle, and terminating explicitly as **RESOLVED** or **EXPIRED**.
@@ -187,7 +187,7 @@ package macp.v1;
 
 message Envelope {
   string macp_version = 1;
-  string mode = 2;
+  string mode = 2;                // empty for ambient Signals
   string message_type = 3;
   string message_id = 4;
   string session_id = 5;          // empty for Signals
@@ -210,10 +210,10 @@ This division is essential: the runtime must be able to enforce boundaries witho
 MACP defines two primary categories of messages:
 
 **Signals (ambient)**  
-Signals MUST have an empty `session_id` (or a session correlation field inside the payload, depending on the mapping). Signals MUST NOT mutate session state.
+Signals MUST have an empty `session_id` and an empty `mode`. If correlation with a session is needed, it SHOULD be carried in `SignalPayload.correlation_session_id` or another payload field. Signals MUST NOT mutate session state.
 
-**Session-scoped messages (coordinated)**  
-Session-scoped messages MUST include `session_id` and MUST be admitted only if the session exists and is OPEN.
+**Session-scoped messages (coordinated)**
+Session-scoped messages MUST include a non-empty `session_id` and a non-empty `mode`, and MUST be admitted only if the session exists and is OPEN.
 
 Modes define additional message types inside sessions, but the session boundary remains invariant.
 
@@ -388,7 +388,7 @@ MACP Core does not guarantee semantic determinism unless the Mode claims it.
 
 A session is replayable only if its execution context is historically exact.
 
-Therefore, sessions SHOULD bind:
+Therefore, sessions MUST bind:
 
 - `mode_version`,
 - `configuration_version`,
@@ -516,7 +516,7 @@ A system that can never force a session to terminate cannot guarantee coherence 
 
 Cancellation is where many systems degrade into ambiguity. MACP treats cancellation as structural.
 
-A compliant runtime MUST support deterministic cancellation that transitions a session from OPEN to EXPIRED without mutating history.
+A compliant runtime MUST support deterministic cancellation that transitions a session from OPEN to EXPIRED without mutating history. By default, only the session initiator is authorized to cancel. Deployments MAY extend cancellation authority through policy.
 
 A runtime SHOULD emit a session-scoped cancellation event (`SessionCancel` Envelope) into the append-only log so that replay preserves the cause of termination.
 

--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -68,14 +68,19 @@ Manifests MAY include `transport_endpoints` to describe how MACP messages can be
 - a concrete URI,
 - one or more supported content types.
 
-Transport identifiers are listed in [`registries/transports.md`](../registries/transports.md).
+Transport identifiers are listed in [`registries/transports.md`](../registries/transports.md). Directly connected `GetManifest` responses may omit `transport_endpoints` when the serving channel already establishes the relevant delivery coordinates or when deployment policy intentionally withholds them.
 
 ## `GetManifest` RPC
 
 For the gRPC binding, manifests can also be retrieved via the `GetManifest` RPC:
 
 - an empty `agent_id` requests the manifest of the serving runtime or agent,
-- a non-empty `agent_id` requests a locally-known manifest for that identifier.
+- a non-empty `agent_id` requests a locally-known manifest for that identifier,
+- self-manifests returned over an already-established channel may omit `transport_endpoints`.
+
+## `ListModes` vs manifest `supported_modes`
+
+`ListModes` returns only standards-track mode descriptors. `GetManifest` and `Initialize` may include both standards-track and extension mode identifiers in `supported_modes`. Extension mode discovery varies by runtime — some runtimes expose a separate extension listing surface.
 
 ## Registry-based Discovery
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -36,13 +36,17 @@ If any check fails, the message is rejected and does not enter history.
 
 ## Accepted-History Discipline
 
-Only **accepted** Envelopes become part of session history. Rejected Envelopes MUST NOT:
+Only **accepted session-scoped** Envelopes become part of authoritative session history. Ambient Signals may be handled ephemerally and are not required to enter durable replay history unless a deployment opts into separate signal logging. Rejected Envelopes MUST NOT:
 
 - be appended to accepted history,
 - consume `message_id` deduplication slots,
 - mutate session state.
 
 All validation, authentication, authorization, deduplication, session-state checks, and Mode-specific structural validation MUST succeed before an Envelope is appended to accepted history.
+
+## Cancellation Authority
+
+The default cancellation authority is the session initiator. Deployments may extend this through policy, but cancellation always requires authentication and authorization.
 
 ## Terminal races
 

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -19,7 +19,7 @@ The main MACP RFC repo should contain only coordination primitives that are broa
 | `macp.mode.handoff.v1` | responsibility transfer | delegated | context-frozen | [RFC-MACP-0010](../rfcs/RFC-MACP-0010-handoff-mode.md) |
 | `macp.mode.quorum.v1` | threshold approval or rejection | quorum | semantic-deterministic | [RFC-MACP-0011](../rfcs/RFC-MACP-0011-quorum-mode.md) |
 
-Everything else - debate, review, critique, pipeline, swarm, auction, marketplace, and organization-specific workflows - should stay in incubator or vendor repos until it proves broad interoperable demand.
+Everything else - debate, review, critique, pipeline, swarm, auction, marketplace, and organization-specific workflows - should stay in incubator or vendor repos until it proves broad interoperable demand. Runtimes may still ship implementation-defined modes for local or product-specific use, but those modes should be documented separately and MUST NOT be counted as main-repo standards unless they appear in the registry and have a corresponding RFC.
 
 ## Why these five modes
 
@@ -62,7 +62,7 @@ Use this rule of thumb:
 
 ### Decision Mode
 
-Decision Mode uses `Proposal`, `Evaluation`, `Objection`, `Vote`, and a final `Commitment`. The participant set is declared up front. The mode standardizes transcript semantics, while policy/configuration decide the exact decision algorithm.
+Decision Mode uses `Proposal`, `Evaluation`, `Objection`, `Vote`, and a final `Commitment`. The participant set is declared up front. The session initiator (coordinator) may emit `Proposal` and `Commitment` even if not listed in `participants`. The mode standardizes transcript semantics, while policy/configuration decide the exact decision algorithm.
 
 ### Proposal Mode
 
@@ -79,6 +79,19 @@ Handoff Mode is for transfer of responsibility, not just work execution. The key
 ### Quorum Mode
 
 Quorum Mode is the narrowest of the five. It covers one approval request and a threshold of approvals, rejections, or abstentions that make the request eligible for a final `Commitment`.
+
+## Extension modes
+
+Runtimes may ship built-in extension modes beyond the five standards-track modes. Extension modes use the `ext.*` namespace (for example `ext.multi_round.v1`) and are not part of the main standards set.
+
+Key differences from standards-track modes:
+
+- `ListModes` returns only standards-track modes. Extensions are discoverable through implementation-defined surfaces.
+- `GetManifest` and `Initialize` may include extension identifiers in `supported_modes` to advertise the full runtime capability.
+- Extension modes do not have canonical schemas or RFCs in this repository.
+- Runtimes may support dynamic registration, removal, and promotion of extension modes.
+
+See [RFC-MACP-0002 §12](../rfcs/RFC-MACP-0002-modes.md) for normative guidance.
 
 ## Schemas and examples
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -13,7 +13,7 @@ A compliant runtime performs a small number of structurally critical jobs:
 2. authenticate and authorize senders,  
 3. validate Envelopes,  
 4. assign accepted messages an authoritative order within a session,  
-5. persist accepted history append-only,  
+5. persist accepted session history append-only,  
 6. execute lifecycle transitions monotonically,  
 7. dispatch accepted messages to the Mode engine.
 
@@ -55,8 +55,8 @@ Mode execution SHOULD be treated as a pure function over accepted history whenev
 
 ## Recovery and rehydration
 
-Because accepted history is append-only, failed owners can recover by replaying the session log and reconstructing in-memory state. Snapshots are an optimization, not an authority.
+Because accepted session history is append-only, failed owners can recover by replaying the session log and reconstructing in-memory state. Snapshots are an optimization, not an authority. Ambient Signals may be handled ephemerally unless a deployment defines a separate signal-log profile.
 
 ## Cancellation
 
-Cancellation transitions a session from OPEN to EXPIRED without rewriting history. Late-arriving messages are rejected because the lifecycle state is no longer OPEN.
+Cancellation transitions a session from OPEN to EXPIRED without rewriting history. By default, only the session initiator is authorized to cancel. Deployments may extend this through policy. Late-arriving messages are rejected because the lifecycle state is no longer OPEN.

--- a/docs/security.md
+++ b/docs/security.md
@@ -98,9 +98,13 @@ Runtimes SHOULD implement admission control for `SessionStart`:
 - Quota enforcement (max concurrent sessions per agent)
 - Policy checks (e.g., only certain agents can initiate certain modes)
 
+### CancelSession Authorization
+
+By default, only the session initiator is authorized to cancel. Deployments MAY extend cancellation authority, but cancellation MUST always require authentication and authorization.
+
 ### Signal Authorization
 
-Signals are ambient and non-binding, but implementations MAY:
+Signals are ambient and non-binding. In the base protocol they carry an empty `session_id` and an empty `mode`; session correlation, if needed, belongs inside `SignalPayload`. Implementations MAY:
 
 - Require authentication for Signal submission
 - Rate limit Signals per agent
@@ -259,6 +263,8 @@ Monitor for:
 | `MODE_NOT_SUPPORTED` | 400 | Referenced mode or mode version not supported | Mode mismatch |
 | `PAYLOAD_TOO_LARGE` | 413 | Payload exceeds limit | DoS mitigation |
 | `RATE_LIMITED` | 429 | Too many requests | DoS mitigation |
+| `INVALID_SESSION_ID` | 400 | session_id format does not meet requirements | Possible attack |
+| `INTERNAL_ERROR` | 500 | Unrecoverable internal runtime error | Retry or escalate |
 | `UNAUTHORIZED` | 403 | Deprecated alias for `FORBIDDEN` | Use `FORBIDDEN` instead |
 
 ## Deployment Best Practices

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -28,11 +28,11 @@ The authoritative per-message request/ack surface. Use `SendResponse.ack` for st
 
 An optional interactive envelope stream, advertised by `sessions.stream = true`. The stream carries canonical MACP Envelopes only — implementations MUST NOT invent ad-hoc pseudo-envelopes for acks or errors. Once bound to a `session_id`, all subsequent session-scoped envelopes on that stream MUST use the same `session_id`.
 
-`StreamSession` is **not** a replacement for unary `Send` acknowledgements. Clients that need per-message negative acknowledgements SHOULD use `Send`.
+`StreamSession` is **not** a replacement for unary `Send` acknowledgements. Clients that need per-message negative acknowledgements SHOULD use `Send`. The base protocol does not define a passive attach/no-op envelope for observing an existing session, and session-scoped `Signal` envelopes are invalid as an attach mechanism. If you need zero-mutation observation, begin streaming before the activity of interest or use a deployment-specific extension outside the base protocol.
 
 ### `WatchModeRegistry` / `WatchRoots` (Server Streaming)
 
-Optional discovery hint streams. A runtime MUST advertise the corresponding capability (`mode_registry.list_changed` or `roots.list_changed`) before these can be assumed interoperable. After receiving a change notification, clients SHOULD re-query the full surface (`ListModes` or `ListRoots`).
+Optional discovery hint streams. A runtime MUST advertise the corresponding capability (`mode_registry.list_changed` or `roots.list_changed`) before these can be assumed interoperable. After receiving a change notification, clients SHOULD re-query the full surface (`ListModes` or `ListRoots`). Minimal implementations may send an initial change hint immediately after stream establishment and then stay idle until a later change occurs. Note that `ListModes` returns only standards-track modes; extension mode discovery is implementation-defined.
 
 ## HTTP
 

--- a/examples/json/signal.json
+++ b/examples/json/signal.json
@@ -1,6 +1,6 @@
 {
   "macp_version": "1.0",
-  "mode": "macp.core.signal.v1",
+  "mode": "",
   "message_type": "Signal",
   "message_id": "01HV0Q1Y8J1J9Q3C2A6JH0ZP3K",
   "session_id": "",

--- a/registries/error-codes.md
+++ b/registries/error-codes.md
@@ -20,6 +20,8 @@ UPPER_SNAKE_CASE
 | MODE_NOT_SUPPORTED | The referenced coordination mode or mode version is not supported for new sessions | 400 | permanent | [RFC-MACP-0002](../rfcs/RFC-MACP-0002-modes.md) |
 | PAYLOAD_TOO_LARGE | Payload exceeds allowed size | 413 | permanent | [RFC-MACP-0001](../rfcs/RFC-MACP-0001-core.md) |
 | RATE_LIMITED | Too many requests | 429 | permanent | [RFC-MACP-0004](../rfcs/RFC-MACP-0004-security.md) |
+| INVALID_SESSION_ID | `session_id` format does not meet deployment requirements (e.g., not a valid UUID or base64url token) | 400 | permanent | [RFC-MACP-0001](../rfcs/RFC-MACP-0001-core.md) |
+| INTERNAL_ERROR | Unrecoverable internal runtime error (e.g., storage failure); clients SHOULD retry or escalate | 500 | permanent | [RFC-MACP-0001](../rfcs/RFC-MACP-0001-core.md) |
 | UNAUTHORIZED | Historical alias for `FORBIDDEN`; new implementations SHOULD use `FORBIDDEN` | 403 | deprecated | [RFC-MACP-0004](../rfcs/RFC-MACP-0004-security.md) |
 
 ## Error Design Principles

--- a/registries/modes.md
+++ b/registries/modes.md
@@ -32,8 +32,14 @@ The main MACP standards repo standardizes only foundational coordination primiti
 - auction and marketplace modes that are still settling semantically,
 - broadcast-style patterns that fit ambient Signals or external pub/sub better than bounded Sessions.
 
-## Experimental Modes
+## Extension and experimental modes
 
-Experimental modes SHOULD use reverse-domain naming, for example:
+Runtime-shipped built-in extensions SHOULD use the `ext.*` namespace:
+
+`ext.<name>.v<major>`
+
+Experimental or vendor-specific modes SHOULD use reverse-domain naming:
 
 `com.example.mode.custom.v1`
+
+Runtimes MAY implement additional non-standard modes, but those modes MUST be documented as non-standard and MUST NOT be presented as part of the standards-track set unless they are listed in this registry and backed by a main-repo RFC. `ListModes` SHOULD return only standards-track modes listed above; extension modes are discoverable through implementation-defined surfaces.

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -80,7 +80,8 @@ The runtime replies with `InitializeResponse` containing:
 - the selected protocol version,
 - runtime identity and implementation information,
 - the runtime capabilities it supports,
-- optionally, a summary of supported modes.
+- optionally, a summary of supported modes,
+- optionally, runtime-specific `instructions` (human-readable guidance or constraints for the client).
 
 The `InitializeRequest` and `InitializeResponse` messages are defined in [`schemas/proto/macp/v1/core.proto`](../schemas/proto/macp/v1/core.proto).
 
@@ -123,6 +124,8 @@ The Ambient Plane carries Signals. Signals MAY be exchanged continuously. Signal
 - change the participant set,
 - resolve or expire a session.
 
+In the base protocol, ambient Signals MUST carry an empty `session_id` and an empty `mode`. If a Signal needs to correlate with a Session, that correlation SHOULD be expressed inside `SignalPayload.correlation_session_id` or another payload-defined field rather than by making the Envelope session-scoped.
+
 ### 5.2 Coordination Plane
 
 The Coordination Plane carries session-scoped messages. A session begins only when `SessionStart` is accepted. There is no implicit coordination.
@@ -154,7 +157,8 @@ For all accepted Envelopes:
 - `message_type` MUST be non-empty,
 - `message_id` MUST be non-empty,
 - `sender` MUST be non-empty,
-- `session_id` MUST be non-empty for session-scoped messages,
+- `session_id` MUST be empty for ambient Signals and non-empty for session-scoped messages,
+- `mode` MUST be empty for ambient Signals and non-empty for session-scoped messages,
 - `sender` MUST be treated as authenticated/derived identity for session-scoped acceptance per RFC-MACP-0004, not as an untrusted self-asserted hint.
 
 Unknown fields MUST be ignored for forward compatibility.
@@ -202,6 +206,8 @@ A session transitions from OPEN to EXPIRED when:
 
 Any session-scoped message referencing a non-OPEN session MUST be rejected.
 
+By default, only the accepted `SessionStart` sender (session initiator) is authorized to submit `CancelSession` for that session. Deployments MAY extend cancellation authority to additional roles through policy, but `CancelSession` MUST be subject to the same authentication and authorization requirements as any session-scoped operation.
+
 ---
 
 ## 8. Delivery, Ordering, and Idempotency
@@ -222,9 +228,9 @@ Duplicate `SessionStart` messages with the same `session_id` but different `mess
 
 ### 8.3 Accepted-History Discipline
 
-Only **accepted** Envelopes become part of accepted history.
+Only **accepted session-scoped** Envelopes become part of authoritative accepted history. Ambient Signals MAY be handled ephemerally and are not required to enter durable replay history unless a deployment explicitly defines a signal-log profile.
 
-Therefore, for any individual Envelope:
+Therefore, for any individual session-scoped Envelope:
 
 - validation,
 - authentication,
@@ -237,7 +243,7 @@ MUST all succeed before the Envelope is appended to accepted history or consumes
 
 Rejected Envelopes MUST NOT:
 
-- be appended to accepted history,
+- be appended to authoritative accepted history,
 - consume `message_id` deduplication slots,
 - mutate session state,
 - or alter replay outcomes except through transient transport-level error reporting.
@@ -285,6 +291,7 @@ MACP defines a canonical JSON mapping for interoperability with REST gateways, d
 |----------------|-----------|---------|
 | `timestamp_unix_ms` (int64) | `timestamp` | RFC3339 string (UTC recommended) |
 | `payload` (bytes) | `payload` or `payload_b64` | See §10.2 |
+| `mode` (string) | `mode` | Empty string for ambient Signals; non-empty for session-scoped messages |
 | `session_id` (string) | `session_id` | Empty string for ambient Signals |
 | All enum fields | Same name | String form of protobuf enum name |
 

--- a/rfcs/RFC-MACP-0002-modes.md
+++ b/rfcs/RFC-MACP-0002-modes.md
@@ -52,7 +52,9 @@ The following patterns are intentionally excluded from the main standards set un
 - fast-moving experimental modes,
 - broadcast-style dissemination patterns that are better modeled as ambient Signals or external pub/sub systems.
 
-Experimental Modes SHOULD use reverse-domain identifiers to avoid collisions.
+Runtimes MAY implement additional non-standard modes. Such modes are not part of the standards-track set unless they are listed in `registries/modes.md` and backed by a main-repo RFC. Discovery surfaces and documentation MUST distinguish these modes from the standards-track set.
+
+Experimental Modes SHOULD use reverse-domain identifiers to avoid collisions. Implementations SHOULD avoid introducing new non-standard modes under the `macp.mode.*` namespace; if a legacy non-standard identifier is retained for compatibility, it MUST NOT be advertised as a standards-track mode.
 
 ## 3. Mode identifiers
 
@@ -64,9 +66,17 @@ Experimental or vendor-specific Modes SHOULD use reverse-domain names, for examp
 
 `com.example.mode.custom.v1`
 
+Runtime-shipped built-in extensions that are not yet standards-track SHOULD use the `ext.*` namespace:
+
+`ext.<name>.v<major>`
+
+For example: `ext.multi_round.v1`
+
+Identifiers in the `macp.mode.*` namespace are reserved for standards-track or explicitly community-governed profiles. New implementation-defined modes SHOULD avoid that namespace unless and until they enter the standards process.
+
 ## 4. Mode Descriptor
 
-A runtime that supports `modeRegistry.listModes` SHOULD expose a machine-readable Mode Descriptor for each supported Mode.
+A runtime that supports `modeRegistry.listModes` SHOULD expose a machine-readable Mode Descriptor for each standards-track Mode it supports. Extension mode descriptors MAY be exposed through implementation-defined discovery surfaces.
 
 A Mode Descriptor SHOULD include:
 
@@ -172,7 +182,19 @@ Promotion criteria:
 - Provisional -> Permanent: stable schemas, at least one interoperable implementation, and community review.
 - Permanent -> Deprecated: replacement Mode available or security/design issues identified. Deprecation SHOULD include a migration guide and transition timeline.
 
-## 12. Security and privacy
+## 12. Extension mode lifecycle
+
+Runtimes MAY support extension modes beyond the standards-track set. Extension mode management is an implementation concern, not a core protocol requirement.
+
+The following guidance applies:
+
+- Extension modes SHOULD use the `ext.*` namespace or reverse-domain identifiers to avoid collision with the reserved `macp.mode.*` namespace.
+- `ListModes` SHOULD return only standards-track modes. Extension mode discovery is implementation-defined; runtimes MAY expose extension modes through separate discovery surfaces.
+- `GetManifest` and `Initialize` MAY include both standards-track and extension mode identifiers in `supported_modes` to advertise the full runtime capability.
+- Runtimes MAY support dynamic registration and removal of extension modes at runtime. Built-in extension modes shipped with the runtime SHOULD NOT be removable.
+- Runtimes MAY support promoting an extension mode to standards-track status. Promotion into the main MACP standards set requires the full process described in §9 and §11.
+
+## 13. Security and privacy
 
 A Mode specification MUST state:
 
@@ -182,6 +204,6 @@ A Mode specification MUST state:
 - what authority scope a `Commitment` carries,
 - how external side effects are made idempotent.
 
-## 13. Interoperability
+## 14. Interoperability
 
 Runtimes SHOULD reject unsupported Mode versions deterministically at `SessionStart` admission time. A Mode MUST NOT silently downgrade behavior without explicit negotiation.

--- a/rfcs/RFC-MACP-0005-discovery-and-manifests.md
+++ b/rfcs/RFC-MACP-0005-discovery-and-manifests.md
@@ -92,7 +92,9 @@ Capabilities MUST be registered in the MACP Capability Registry (see [`registrie
 
 Agents declare supported coordination modes. Modes are defined in [RFC-MACP-0002](RFC-MACP-0002-modes.md) and, for the standards-track mode set in this repo, in [RFC-MACP-0007](RFC-MACP-0007-decision-mode.md) through [RFC-MACP-0011](RFC-MACP-0011-quorum-mode.md).
 
-If a runtime exposes `ListModes`, the manifest SHOULD be consistent with the runtime's mode registry output.
+The `supported_modes` field in an AgentManifest MAY include both standards-track and non-standard mode identifiers (for example extension modes using the `ext.*` namespace). Clients SHOULD NOT assume that every identifier in `supported_modes` is a standards-track mode.
+
+If a runtime exposes `ListModes`, the manifest's `supported_modes` MAY be a superset of the `ListModes` output because `ListModes` SHOULD return only standards-track modes while the manifest advertises the full runtime capability.
 
 ## 6. Transport Endpoints
 
@@ -107,7 +109,7 @@ Supported transport types include registered MACP transport identifiers such as:
 
 Registered transport identifiers are listed in [`registries/transports.md`](../registries/transports.md).
 
-`transport_endpoints` is OPTIONAL, but publishers SHOULD include at least one entry when the manifest is intended for network discovery by third parties.
+`transport_endpoints` is OPTIONAL, but publishers SHOULD include at least one entry when the manifest is intended for network discovery by third parties. A directly connected `GetManifest` response MAY omit `transport_endpoints` when the current channel already establishes delivery coordinates or when deployment policy intentionally withholds them.
 
 ## 7. Discovery Mechanisms
 
@@ -129,7 +131,8 @@ For the gRPC binding:
 
 - an empty `GetManifestRequest.agent_id` requests the manifest of the serving runtime or agent,
 - a non-empty `agent_id` requests a locally-known manifest for that identifier,
-- if no such manifest is available, the runtime SHOULD return a transport-native not-found error.
+- if no such manifest is available, the runtime SHOULD return a transport-native not-found error,
+- self-manifests returned over an already-established channel MAY omit `transport_endpoints` when the serving channel itself is the relevant delivery coordinate.
 
 ## 8. Manifest Versioning
 

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -67,16 +67,20 @@ A runtime that advertises `sessions.stream = true` MUST implement `StreamSession
 
 A runtime MAY echo back accepted client-submitted envelopes on the stream as part of the authoritative accepted sequence.
 
+The base protocol does **not** define a passive attach or no-op envelope for observing an existing session without sending a new session-scoped coordination message. Session-scoped `Signal` envelopes are invalid in the base protocol and MUST NOT be used as a stream-attach mechanism. Clients that need zero-mutation observation SHOULD either begin streaming before the session activity of interest or rely on a deployment-specific extension outside the base protocol.
+
 When a transport-level or stream-fatal error occurs, the runtime SHOULD use native gRPC stream termination semantics.
 
 ### 3.3 `WatchModeRegistry` and `WatchRoots`
 
 These watch streams are optional discovery hints.
 
+`ListModes` SHOULD return only standards-track mode descriptors. Extension mode descriptors are discoverable through implementation-defined surfaces and are not part of the base `ListModes` response.
+
 A runtime MUST advertise `mode_registry.list_changed = true` before `WatchModeRegistry` can be assumed interoperable.
 A runtime MUST advertise `roots.list_changed = true` before `WatchRoots` can be assumed interoperable.
 
-A watch notification indicates that the corresponding registry or roots view may have changed. Clients SHOULD re-query the full surface (`ListModes` or `ListRoots`) after receiving a change notification.
+A watch notification indicates that the corresponding registry or roots view may have changed. Clients SHOULD re-query the full surface (`ListModes` or `ListRoots`) after receiving a change notification. A minimal compliant implementation MAY send an initial change hint immediately after stream establishment and then remain idle until a later change occurs.
 
 ## 4. HTTP Binding
 

--- a/rfcs/RFC-MACP-0007-decision-mode.md
+++ b/rfcs/RFC-MACP-0007-decision-mode.md
@@ -8,7 +8,7 @@
 
 ## Abstract
 
-This document defines `macp.mode.decision.v1`, the standards-track Decision Mode for bounded multi-party decisions. Decision Mode lets declared participants submit proposals, evaluations, objections, and votes, and it terminates with a single authoritative `Commitment`.
+This document defines `macp.mode.decision.v1`, the standards-track Decision Mode for bounded multi-party decisions. Decision Mode lets declared participants submit proposals, evaluations, objections, and votes, and it terminates with a single authoritative `Commitment`. The accepted `SessionStart` sender (session initiator/coordinator) may also be separately authorized to emit `Proposal` and `Commitment`.
 
 ## 1. Purpose
 
@@ -25,11 +25,11 @@ Decision Mode is intentionally narrower than a general workflow engine:
 - **Mode identifier:** `macp.mode.decision.v1`
 - **Participant model:** `declared`
 
-The eligible participant set is bound at `SessionStart`. Only declared participants MAY emit Decision Mode messages.
+The eligible participant set is bound at `SessionStart`. Declared participants MAY emit `Proposal`, `Evaluation`, `Objection`, and `Vote`. The accepted `SessionStart` sender (session initiator/coordinator) MAY emit `Proposal` and `Commitment` even if not listed in `participants`, unless a stricter policy is bound by configuration or policy.
 
 ## 3. SessionStart requirements
 
-A Decision Mode Session SHOULD bind the following fields explicitly in `SessionStartPayload`:
+A Decision Mode Session MUST bind the following fields explicitly in `SessionStartPayload`:
 
 - `participants` - decision participants,
 - `mode_version` - the decision-mode semantic profile,
@@ -83,8 +83,8 @@ Given the same accepted message history, the same participant set, and the same 
 
 Implementations MUST address all of the following:
 
-- authenticate the sender of each evaluation, objection, vote, and commitment,
-- reject messages from non-participants,
+- authenticate the sender of each proposal, evaluation, objection, vote, and commitment,
+- reject Decision Mode messages from unauthorized senders, distinguishing declared-participant authority from any separately bound coordinator authority,
 - protect confidential decision context and proposal data,
 - ensure only authorized actors can emit `Commitment`,
 - preserve append-only accepted history for audit and replay.

--- a/rfcs/RFC-MACP-0008-proposal-mode.md
+++ b/rfcs/RFC-MACP-0008-proposal-mode.md
@@ -19,11 +19,11 @@ Proposal Mode standardizes a common negotiation shape without forcing the heavie
 - **Mode identifier:** `macp.mode.proposal.v1`
 - **Participant model:** `peer`
 
-The participant roles are symmetric, but the participant set SHOULD still be bound at `SessionStart`.
+The participant roles are symmetric, but the participant set MUST still be bound at `SessionStart`.
 
 ## 3. SessionStart requirements
 
-A Proposal Mode Session SHOULD bind:
+A Proposal Mode Session MUST bind:
 
 - `participants` - required negotiating parties,
 - `mode_version` - proposal-mode semantic profile,

--- a/rfcs/RFC-MACP-0009-task-mode.md
+++ b/rfcs/RFC-MACP-0009-task-mode.md
@@ -23,7 +23,7 @@ The session initiator or a policy-defined coordinator is the requester and defau
 
 ## 3. SessionStart requirements
 
-A Task Mode Session SHOULD bind:
+A Task Mode Session MUST bind:
 
 - `participants` - requester and eligible assignee participants,
 - `mode_version` - task-mode semantic profile,

--- a/rfcs/RFC-MACP-0010-handoff-mode.md
+++ b/rfcs/RFC-MACP-0010-handoff-mode.md
@@ -23,7 +23,7 @@ The current owner or a policy-defined coordinator is the default `Commitment` au
 
 ## 3. SessionStart requirements
 
-A Handoff Mode Session SHOULD bind:
+A Handoff Mode Session MUST bind:
 
 - `participants` - current owner and eligible targets,
 - `mode_version` - handoff semantic profile,

--- a/rfcs/RFC-MACP-0011-quorum-mode.md
+++ b/rfcs/RFC-MACP-0011-quorum-mode.md
@@ -19,11 +19,11 @@ Quorum Mode is appropriate when one bounded action requires N-of-M approval rath
 - **Mode identifier:** `macp.mode.quorum.v1`
 - **Participant model:** `quorum`
 
-The participant set is typically declared at `SessionStart`, but resolution is based on a threshold rather than unanimity.
+The participant set MUST be declared at `SessionStart`, but resolution is based on a threshold rather than unanimity.
 
 ## 3. SessionStart requirements
 
-A Quorum Mode Session SHOULD bind:
+A Quorum Mode Session MUST bind:
 
 - `participants` - eligible approvers,
 - `mode_version` - quorum-mode semantic profile,

--- a/schemas/json/macp-envelope.schema.json
+++ b/schemas/json/macp-envelope.schema.json
@@ -22,8 +22,7 @@
     },
     "mode": {
       "type": "string",
-      "minLength": 1,
-      "description": "Mode identifier (e.g., macp.core.signal.v1, macp.mode.decision.v1)."
+      "description": "Empty string for ambient Signals; canonical mode identifier for session-scoped messages (for example macp.mode.decision.v1)."
     },
     "message_type": {
       "type": "string",
@@ -37,7 +36,7 @@
     },
     "session_id": {
       "type": "string",
-      "description": "Empty for ambient Signals; non-empty for session-scoped messages."
+      "description": "Empty string for ambient Signals; non-empty for session-scoped messages."
     },
     "sender": {
       "type": "string",
@@ -106,8 +105,24 @@
       },
       "then": {
         "properties": {
+          "mode": {
+            "maxLength": 0
+          },
+          "session_id": {
+            "maxLength": 0
+          },
           "payload": {
             "$ref": "#/$defs/SignalPayload"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "mode": {
+            "minLength": 1
+          },
+          "session_id": {
+            "minLength": 1
           }
         }
       }
@@ -219,7 +234,9 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "ttl_ms"
+        "ttl_ms",
+        "mode_version",
+        "configuration_version"
       ],
       "properties": {
         "intent": {
@@ -232,10 +249,12 @@
           }
         },
         "mode_version": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "configuration_version": {
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "ttl_ms": {
           "type": "integer",

--- a/schemas/proto/macp/v1/envelope.proto
+++ b/schemas/proto/macp/v1/envelope.proto
@@ -6,7 +6,7 @@ package macp.v1;
 
 message Envelope {
   string macp_version = 1;
-  string mode = 2;
+  string mode = 2;             // empty for ambient Signals
   string message_type = 3;
   string message_id = 4;
   string session_id = 5;       // empty for ambient messages


### PR DESCRIPTION

  ## Summary

  - **Signal envelope rules**: Require empty `mode` and `session_id` for ambient Signals across
    RFC-0001, JSON schema (conditional validation), proto comment, and signal.json example.
    Removes stale `macp.core.signal.v1` mode identifier from examples.
  - **SessionStart strictness**: Upgrade SHOULD → MUST for field binding in all five mode RFCs
    (0007–0011). Add `mode_version` and `configuration_version` to JSON schema required fields
    to match RFC-0001 §7.1 and runtime enforcement.
  - **Decision Mode authority**: Document the coordinator/initiator model — initiator may emit
    `Proposal` and `Commitment` even if not in `participants`, matching the runtime and existing
    example transcript.
  - **CancelSession authority**: Add normative default to RFC-0001 §7.3 — initiator-only by
    default, deployments may extend through policy.
  - **Extension mode model**: Document the `ext.*` namespace for runtime-shipped built-in
    extensions. Add RFC-0002 §12 covering extension lifecycle guidance (registration, removal,
    promotion). Clarify that `ListModes` returns standards-track only while `GetManifest` /
    `Initialize` may include extensions.
  - **Accepted history**: Clarify as session-scoped; Signals may be handled ephemerally.
  - **StreamSession**: Clarify no passive attach envelope; session-scoped Signals are invalid.
  - **Discovery**: Clarify `transport_endpoints` may be omitted in directly connected
    `GetManifest` responses. Add `ListModes` vs manifest `supported_modes` distinction.
  - **Docs consistency**: All explanatory docs updated to match normative changes.

  ## Files changed (22 files, +145 −54)

  **Normative RFCs:**
  - `rfcs/RFC-MACP-0001-core.md` — Signal rules, accepted history, cancel authority, field mapping
  - `rfcs/RFC-MACP-0002-modes.md` — ext.* namespace, ListModes scoping, §12 extension lifecycle
  - `rfcs/RFC-MACP-0005-discovery-and-manifests.md` — supported_modes clarification, transport_endpoints
  - `rfcs/RFC-MACP-0006-transport-bindings.md` — StreamSession attach, ListModes scope, watch hints
  - `rfcs/RFC-MACP-0007-decision-mode.md` — Coordinator authority, SHOULD→MUST
  - `rfcs/RFC-MACP-0008-proposal-mode.md` — SHOULD→MUST
  - `rfcs/RFC-MACP-0009-task-mode.md` — SHOULD→MUST
  - `rfcs/RFC-MACP-0010-handoff-mode.md` — SHOULD→MUST
  - `rfcs/RFC-MACP-0011-quorum-mode.md` — SHOULD→MUST

  **Schemas:**
  - `schemas/json/macp-envelope.schema.json` — Conditional mode/session_id validation, SessionStartPayload required fields
  - `schemas/proto/macp/v1/envelope.proto` — Comment on mode field

  **Registries:**
  - `registries/modes.md` — ext.* namespace, ListModes scope
  - `registries/error-codes.md` — Minor addition

  **Examples:**
  - `examples/json/signal.json` — Empty mode, trailing newline fix

  **Docs:**
  - `docs/architecture.md`, `docs/discovery.md`, `docs/lifecycle.md`, `docs/modes.md`,
    `docs/runtime.md`, `docs/security.md`, `docs/transports.md` — Consistent with normative changes

  **Root:**
  - `README.md` — Mode boundary clarification

  ## What is NOT changed

  - `core.proto` — No new messages or RPCs added (extension lifecycle RPCs like ListExtModes are
    implementation-specific, not core protocol)
  - No new RFC created — extension guidance fits in RFC-0002 §12
  - multi_round is not added to the spec repo — it remains a runtime extension

  ## Test plan

  - [ ] `python3 -c "import json; json.load(open('schemas/json/macp-envelope.schema.json'))"` — schema valid
  - [ ] All `examples/**/*.json` parse as valid JSON
  - [ ] `grep -r "macp.core.signal" .` returns nothing (stale identifier removed)
  - [ ] `grep -r "SHOULD bind" rfcs/*-mode.md` returns only Commitment content refs, not SessionStart
  - [ ] `grep -r "ListExtModes" rfcs/ schemas/` returns nothing (not in core proto)
  - [ ] `grep -r "ext\.\*" rfcs/ docs/ registries/` shows consistent ext.* documentation