### PR TITLE
Add WatchSignals streaming RPC for ambient signal observation

### DIFF
--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -126,6 +126,8 @@ The Ambient Plane carries Signals. Signals MAY be exchanged continuously. Signal
 
 In the base protocol, ambient Signals MUST carry an empty `session_id` and an empty `mode`. If a Signal needs to correlate with a Session, that correlation SHOULD be expressed inside `SignalPayload.correlation_session_id` or another payload-defined field rather than by making the Envelope session-scoped.
 
+Runtimes MAY support a `WatchSignals` streaming RPC (see RFC-MACP-0006 §3.4) to broadcast accepted Signal envelopes to all subscribers in real time. Signals are ephemeral and are not required to enter durable replay history.
+
 ### 5.2 Coordination Plane
 
 The Coordination Plane carries session-scoped messages. A session begins only when `SessionStart` is accepted. There is no implicit coordination.

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -43,6 +43,7 @@ service MACPRuntimeService {
   rpc WatchModeRegistry(WatchModeRegistryRequest) returns (stream WatchModeRegistryResponse);
   rpc ListRoots(ListRootsRequest) returns (ListRootsResponse);
   rpc WatchRoots(WatchRootsRequest) returns (stream WatchRootsResponse);
+  rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
 }
 ```
 
@@ -81,6 +82,21 @@ A runtime MUST advertise `mode_registry.list_changed = true` before `WatchModeRe
 A runtime MUST advertise `roots.list_changed = true` before `WatchRoots` can be assumed interoperable.
 
 A watch notification indicates that the corresponding registry or roots view may have changed. Clients SHOULD re-query the full surface (`ListModes` or `ListRoots`) after receiving a change notification. A minimal compliant implementation MAY send an initial change hint immediately after stream establishment and then remain idle until a later change occurs.
+
+### 3.4 `WatchSignals`
+
+`WatchSignals` is an optional server-streaming RPC that broadcasts ambient Signal envelopes to all subscribers.
+
+Signals are non-binding messages on the ambient plane (per RFC-MACP-0001 §5.1). They MUST carry empty `session_id` and empty `mode` in the Envelope. Signals MUST NOT enter any session's accepted history or mutate session state.
+
+A `WatchSignalsResponse` contains the full `Envelope` of each accepted Signal. The `SignalPayload` within the envelope MAY include a `correlation_session_id` to indicate which session the signal relates to, without making the Signal session-scoped.
+
+Use cases include:
+- progress notifications from agents working on evaluations
+- heartbeat and liveness signals
+- status updates between coordination steps
+
+A runtime that supports `WatchSignals` MUST broadcast all accepted Signal envelopes to all active subscribers. Signals are ephemeral — they are not persisted and are not available for replay.
 
 ## 4. HTTP Binding
 

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -277,6 +277,12 @@ message PromoteModeResponse {
   string mode = 3;
 }
 
+message WatchSignalsRequest {}
+
+message WatchSignalsResponse {
+  Envelope envelope = 1;
+}
+
 service MACPRuntimeService {
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -293,4 +299,6 @@ service MACPRuntimeService {
   rpc RegisterExtMode(RegisterExtModeRequest) returns (RegisterExtModeResponse);
   rpc UnregisterExtMode(UnregisterExtModeRequest) returns (UnregisterExtModeResponse);
   rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
+  // Ambient signal observation
+  rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
 }


### PR DESCRIPTION
## Summary

  - Add `WatchSignals` server-streaming RPC to `MACPRuntimeService` for broadcasting ambient Signal envelopes to subscribers in real time
  - Define `WatchSignalsRequest` and `WatchSignalsResponse` messages in `core.proto`
  - Document the `WatchSignals` RPC in RFC-MACP-0006 §3.4 with semantics, constraints, and use cases
  - Update RFC-MACP-0001 §5.1 to cross-reference the new RPC and clarify that Signals are ephemeral

  ## Test plan

  - [ ] Verify `core.proto` compiles: `protoc --proto_path=schemas/proto --descriptor_set_out=/dev/null schemas/proto/macp/v1/core.proto`
  - [ ] Confirm RFC-MACP-0006 §3.4 correctly describes the streaming semantics and invariants
  - [ ] Validate that Signal ephemeral/non-binding guarantees are preserved (empty `session_id`, no session history mutation)