### PR TITLE
Add ParticipantActivity tracking to SessionMetadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,6 +396,8 @@ Therefore, sessions MUST bind:
 
 as immutable session metadata. These values MUST NOT change within an OPEN session.
 
+`SessionMetadata` also carries mutable runtime-derived fields — the current participant list and per-participant activity summaries (`ParticipantActivity`) — that reflect evolving session state rather than bound-at-start configuration.
+
 If policies evolve over time, they evolve between sessions, not within one.
 
 ### 9.4 Mode-level determinism claims

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -34,6 +34,14 @@ An optional interactive envelope stream, advertised by `sessions.stream = true`.
 
 Optional discovery hint streams. A runtime MUST advertise the corresponding capability (`mode_registry.list_changed` or `roots.list_changed`) before these can be assumed interoperable. After receiving a change notification, clients SHOULD re-query the full surface (`ListModes` or `ListRoots`). Minimal implementations may send an initial change hint immediately after stream establishment and then stay idle until a later change occurs. Note that `ListModes` returns only standards-track modes; extension mode discovery is implementation-defined.
 
+### `WatchSignals` (Server Streaming)
+
+An optional server-streaming RPC that broadcasts ambient Signal envelopes to all subscribers. Signals are non-binding messages on the ambient plane — they carry empty `session_id` and empty `mode` in the Envelope. A `SignalPayload` MAY include a `correlation_session_id` to relate the signal to a session without making it session-scoped. Signals are ephemeral and are not available for replay. See [RFC-MACP-0006 §3.4](../rfcs/RFC-MACP-0006-transport-bindings.md#34-watchsignals).
+
+### `GetSession` (Unary)
+
+Returns a `SessionMetadata` snapshot for a given session, including the session's identity, state, timing, bound version fields, the current participant list, and per-participant activity summaries (`ParticipantActivity` with `participant_id`, `last_message_at_unix_ms`, `message_count`).
+
 ## HTTP
 
 Best for:

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -269,13 +269,16 @@ The canonical gRPC service definition is `MACPRuntimeService` in [`schemas/proto
 - `Initialize` — unary initialization and capability negotiation
 - `Send` — unary envelope send with acknowledgement
 - `StreamSession` — bidirectional session streaming
-- `GetSession` — session metadata query
+- `GetSession` — session metadata query; returns `SessionMetadata` including the current participant list and per-participant activity summaries (`ParticipantActivity`)
 - `CancelSession` — explicit session cancellation
 - `GetManifest` — agent or runtime manifest retrieval
 - `ListModes` — mode registry query
 - `WatchModeRegistry` — mode registry change notifications
 - `ListRoots` — root listing
 - `WatchRoots` — root change notifications
+- `WatchSignals` — ambient signal observation (server streaming)
+
+The proto file also defines extension mode lifecycle RPCs (`ListExtModes`, `RegisterExtMode`, `UnregisterExtMode`, `PromoteMode`); see [RFC-MACP-0002](RFC-MACP-0002-modes.md) for extension mode semantics.
 
 Runtimes MAY expose additional bindings, including REST/JSON, provided the canonical Envelope and JSON mapping semantics are preserved. Standard transport bindings are defined in [RFC-MACP-0006](RFC-MACP-0006-transport-bindings.md).
 

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -43,6 +43,12 @@ service MACPRuntimeService {
   rpc WatchModeRegistry(WatchModeRegistryRequest) returns (stream WatchModeRegistryResponse);
   rpc ListRoots(ListRootsRequest) returns (ListRootsResponse);
   rpc WatchRoots(WatchRootsRequest) returns (stream WatchRootsResponse);
+  // Extension mode lifecycle
+  rpc ListExtModes(ListExtModesRequest) returns (ListExtModesResponse);
+  rpc RegisterExtMode(RegisterExtModeRequest) returns (RegisterExtModeResponse);
+  rpc UnregisterExtMode(UnregisterExtModeRequest) returns (UnregisterExtModeResponse);
+  rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
+  // Ambient signal observation
   rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
 }
 ```
@@ -97,6 +103,14 @@ Use cases include:
 - status updates between coordination steps
 
 A runtime that supports `WatchSignals` MUST broadcast all accepted Signal envelopes to all active subscribers. Signals are ephemeral — they are not persisted and are not available for replay.
+
+### 3.5 `GetSession`
+
+`GetSession` returns a `SessionMetadata` snapshot for the given session. The response includes the session's identity, state, timing, and bound version fields (`mode_version`, `configuration_version`, `policy_version`), as well as the current participant list and per-participant activity summaries (`ParticipantActivity`). The `ParticipantActivity` entries provide `participant_id`, `last_message_at_unix_ms`, and `message_count` for each participant that has sent at least one accepted message.
+
+### 3.6 Extension Mode Lifecycle RPCs
+
+`ListExtModes`, `RegisterExtMode`, `UnregisterExtMode`, and `PromoteMode` manage the lifecycle of non-standards-track (extension) coordination modes. These RPCs are implementation-defined surfaces for registering, discovering, and promoting experimental modes. See [RFC-MACP-0002](RFC-MACP-0002-modes.md) for extension mode semantics and the relationship between extension and standards-track modes.
 
 ## 4. HTTP Binding
 

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -120,6 +120,12 @@ message CommitmentPayload {
   string configuration_version = 7;
 }
 
+message ParticipantActivity {
+  string participant_id = 1;
+  int64 last_message_at_unix_ms = 2;
+  uint32 message_count = 3;
+}
+
 message SessionMetadata {
   string session_id = 1;
   string mode = 2;
@@ -129,6 +135,8 @@ message SessionMetadata {
   string mode_version = 6;
   string configuration_version = 7;
   string policy_version = 8;
+  repeated string participants = 9;
+  repeated ParticipantActivity participant_activity = 10;
 }
 
 message GetSessionRequest {


### PR DESCRIPTION
## Summary
                                                                                                                                                                        
  - Add `ParticipantActivity` message and `participants`/`participant_activity` fields to `SessionMetadata` in `core.proto`, enriching the `GetSession` response with   
  per-participant tracking                                                                                                                                              
  - Update RFC-MACP-0001 Section 9 RPC listing to include `WatchSignals` and document the enriched `GetSession` response                                                
  - Sync RFC-MACP-0006 convenience service listing with the actual proto (adds extension mode lifecycle RPCs), add §3.5 (`GetSession`) and §3.6 (Extension Mode         
  Lifecycle RPCs)                                                                                                                                                       
  - Add `WatchSignals` and `GetSession` sections to `docs/transports.md`                                                                                                
  - Clarify in `docs/architecture.md` that `SessionMetadata` carries both immutable version-binding fields and mutable runtime-derived fields                           
                                                                  
  ## Test plan                                                                                                                                                          
                                                                  
  - [ ] Verify proto compiles: `protoc --proto_path=schemas/proto --descriptor_set_out=/dev/null schemas/proto/macp/v1/envelope.proto schemas/proto/macp/v1/core.proto` 
  - [ ] Verify RFC-0006 service listing matches the proto service block exactly
  - [ ] Grep for `ParticipantActivity` across RFCs/docs to confirm consistent documentation                                                                             
  - [ ] Review cross-references (RFC links, proto file links) resolve correctly                                                                                         
                                                                           