### PR TITLE
 Add session extensions, lifecycle observation RPCs, and policy rules…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,19 @@ jobs:
           chmod +x scripts/sync-proto-packages.sh
           ./scripts/sync-proto-packages.sh --check
 
+      - name: Check SDK proto parity (W3a / direct-agent-auth)
+        run: |
+          echo "Checking typescript-sdk + python-sdk proto ranges match the canonical packages..."
+          chmod +x scripts/check-proto-parity.sh
+          # The parity script requires the SDK sibling repos to be present on disk.
+          # In CI this is only meaningful on a checkout that includes them — skip cleanly otherwise.
+          if [ -d ../typescript-sdk ] && [ -d ../python-sdk ]; then
+            ./scripts/check-proto-parity.sh
+          else
+            echo "SKIP: ../typescript-sdk or ../python-sdk not present in this checkout."
+            echo "This check runs in the monorepo-wide CI that checks out all sibling repos."
+          fi
+
   lint-protobuf:
     name: Lint Protocol Buffers
     runs-on: ubuntu-latest

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -51,3 +51,21 @@ The default cancellation authority is the session initiator. Deployments may ext
 ## Terminal races
 
 If multiple terminal messages are sent concurrently, the first one accepted into the session log determines the outcome. Later terminal messages are rejected because the session is no longer OPEN.
+
+## Session Observation
+
+Two RPCs provide programmatic session lifecycle observation:
+
+- **`ListSessions`** — returns `SessionMetadata` for all known sessions. Use for initial sync. Advertised by `sessions.list_sessions`.
+- **`WatchSessions`** — server-streaming RPC that emits `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED) in real time. Advertised by `sessions.watch_sessions`.
+
+Control-planes and UIs typically call `ListSessions` on startup for a snapshot, then subscribe to `WatchSessions` for incremental updates. Events are ephemeral and not replayed.
+
+## Session Context and Extensions
+
+Sessions may carry optional context and extension metadata (see [RFC-MACP-0001 §7.4](../rfcs/RFC-MACP-0001-core.md)):
+
+- **`context_id`** — an opaque string naming the structured context the session operates within (e.g., a content-addressed ID, a URI). The runtime preserves it but never interprets it.
+- **`extensions`** — a map of protocol-keyed byte blocks for protocol-specific metadata (e.g., CTXM, AITP). The runtime preserves all entries but does not depend on them for core lifecycle.
+
+Both are optional. A session with empty `context_id` and empty `extensions` behaves identically to one with both populated.

--- a/docs/onboarding-an-agent.md
+++ b/docs/onboarding-an-agent.md
@@ -1,0 +1,237 @@
+# Onboarding an agent
+
+> How to add a new MACP-compliant agent to a deployment. One page, five steps.
+
+Under the **direct-agent-auth** architecture (see `ui-console/plans/direct-agent-auth.md`):
+
+- Every agent authenticates to the runtime **directly** via Bearer token.
+- The control-plane **never** emits envelopes on behalf of agents — it is a scenario-agnostic observer.
+- The initiator agent of a session calls `Send(SessionStart)` itself; non-initiator participants open their own `StreamSession` to receive events and emit their own envelopes.
+
+This page shows how to onboard agent **N** in a static-token deployment (i.e., before Phase 6 JWT federation lands). Once Phase 6 ships, step 2 changes to "issue a JWT via the auth service"; the rest stays the same.
+
+---
+
+## Prerequisites
+
+- A running MACP runtime with its gRPC endpoint reachable from your agent process (e.g., `runtime.internal:50051`).
+- Admin access to the runtime's environment (`MACP_AUTH_TOKENS_JSON`).
+- Admin access to the scenario-producing tier (e.g., examples-service `EXAMPLES_SERVICE_AGENT_TOKENS_JSON`).
+- Either `macp-sdk-python >= 0.2.0` (PyPI) or `macp-sdk-typescript >= 0.2.0` (npm) available to your agent runtime.
+
+---
+
+## Step 1 — Decide the agent's sender id
+
+The **sender** is the plain-string identity the runtime binds to this agent (RFC-MACP-0001 §6). Bare names are fine:
+
+```
+risk-agent
+fraud-agent
+my-new-agent
+```
+
+The `agent://…` prefix is a convention used by some integration tests, not a protocol requirement.
+
+**Rules:**
+- Must be non-empty.
+- Must be unique across all agents that can talk to the same runtime identity registry.
+- Must match the `sender` field in the runtime's identity entry for this agent (step 2).
+
+---
+
+## Step 2 — Generate a Bearer token and register the identity on the runtime
+
+Generate a strong random token:
+
+```bash
+openssl rand -hex 32
+```
+
+Add an entry to the runtime's `MACP_AUTH_TOKENS_JSON`. The runtime loads this map once at boot (`runtime/src/security.rs:109-157`):
+
+```json
+{
+  "tokens": [
+    { "token": "<existing-agents>", "sender": "risk-agent",  "can_start_sessions": true },
+    { "token": "<existing-agents>", "sender": "fraud-agent", "can_start_sessions": true },
+    // add:
+    {
+      "token": "<your-new-token>",
+      "sender": "my-new-agent",
+      "can_start_sessions": true,
+      "allowed_modes": ["macp.mode.decision.v1"],
+      "max_open_sessions": 10
+    }
+  ]
+}
+```
+
+**Capability guidance:**
+
+| Flag | Set it when… |
+|------|-------------|
+| `can_start_sessions: true` | The agent may be a session initiator for at least one scenario. |
+| `allowed_modes: [...]` | You want to restrict which modes the agent may send in. Empty/absent = unrestricted. |
+| `max_open_sessions: N` | You want per-agent concurrency caps. |
+| `can_manage_mode_registry: true` | The agent manages registered modes/policies (rare; usually false). |
+
+Redeploy the runtime (or wait for hot-reload, if your deployment supports it).
+
+---
+
+## Step 3 — Register the token on the scenario-producing tier
+
+In `examples-service/.env` (or equivalent), add an entry to `EXAMPLES_SERVICE_AGENT_TOKENS_JSON`:
+
+```json
+{
+  "risk-agent":    "<existing token>",
+  "fraud-agent":   "<existing token>",
+  "my-new-agent":  "<your-new-token>"
+}
+```
+
+The examples-service injects `runtime.bearerToken` into each agent's bootstrap at spawn time by looking up the sender in this map.
+
+If you are running in a different scenario-producing tier, inject the equivalent env var using that tier's conventions. The only requirement is that the agent's bootstrap ends up with the correct Bearer token in `runtime.bearerToken`.
+
+---
+
+## Step 4 — Register the agent in the scenario catalog
+
+In `examples-service/src/example-agents/example-agent-catalog.service.ts`, add an entry:
+
+```ts
+{
+  agentRef: 'my-new-agent',
+  framework: 'python' /* or 'langgraph' | 'langchain' | 'crewai' | 'node' */,
+  role: 'evaluator',
+  entrypoint: 'agents/my_new_agent/main.py', // or 'src/example-agents/runtime/my-new-agent.worker.ts'
+  bootstrap: { strategy: 'external' },
+  supportedScenarioRefs: ['fraud/high-value-new-device@1.0.0'],
+}
+```
+
+Then add the agent to the scenario's `participants` list in its YAML.
+
+---
+
+## Step 5 — Pick an SDK and wire the agent loop
+
+### Python
+
+```python
+import os
+from macp_sdk import MacpClient, AuthConfig, DecisionSession, new_session_id
+from macp_worker_sdk import load_bootstrap
+
+bootstrap = load_bootstrap()
+auth = AuthConfig.for_bearer(
+    os.environ["MACP_RUNTIME_TOKEN"],
+    expected_sender=bootstrap.participant.participant_id,
+)
+
+client = MacpClient(
+    target=os.environ["MACP_RUNTIME_ADDRESS"],
+    secure=os.environ.get("MACP_RUNTIME_TLS", "true").lower() == "true",
+    auth=auth,
+)
+client.initialize()
+
+session = DecisionSession(client, session_id=bootstrap.run.session_id, auth=auth)
+
+if bootstrap.initiator is not None:
+    # Initiator path — emit SessionStart, then kickoff.
+    session.start(
+        intent=bootstrap.initiator.session_start.intent,
+        participants=bootstrap.initiator.session_start.participants,
+        ttl_ms=bootstrap.initiator.session_start.ttl_ms,
+        mode_version=bootstrap.initiator.session_start.mode_version,
+        configuration_version=bootstrap.initiator.session_start.configuration_version,
+        policy_version=bootstrap.initiator.session_start.policy_version,
+    )
+    stream = session.open_stream()
+    if bootstrap.initiator.kickoff is not None:
+        session.propose(bootstrap.initiator.kickoff.payload)  # or send raw envelope
+else:
+    # Non-initiator — just open the stream and react to events.
+    stream = session.open_stream()
+
+for envelope in stream.responses():
+    # handle Proposal / Evaluation / Vote / Commitment / ...
+    ...
+```
+
+### TypeScript
+
+```ts
+import { MacpClient, Auth, DecisionSession, newSessionId } from 'macp-sdk-typescript';
+import { loadBootstrap } from './bootstrap';
+
+const bootstrap = loadBootstrap();
+const auth = Auth.bearer(process.env.MACP_RUNTIME_TOKEN!, {
+  expectedSender: bootstrap.participant.participantId,
+});
+
+const client = new MacpClient({
+  address: process.env.MACP_RUNTIME_ADDRESS!,
+  secure: process.env.MACP_RUNTIME_TLS === 'true',
+  auth,
+});
+await client.initialize();
+
+const session = new DecisionSession(client, { sessionId: bootstrap.run.sessionId, auth });
+
+if (bootstrap.initiator) {
+  await session.start(bootstrap.initiator.sessionStart);
+  const stream = session.openStream();
+  if (bootstrap.initiator.kickoff) {
+    await session.propose(bootstrap.initiator.kickoff.payload);
+  }
+  for await (const envelope of stream.responses()) {
+    // handle events
+  }
+} else {
+  const stream = session.openStream();
+  for await (const envelope of stream.responses()) {
+    // handle events
+  }
+}
+```
+
+### Cancellation (Option A — RFC-pure default)
+
+Expose a local HTTP `POST <cancelCallback.path>` endpoint from your agent. The control-plane's UI-triggered cancel calls it; your agent responds by calling `session.cancel(reason)` on the runtime with its own identity. Runtime enforces RFC-MACP-0001 §7.2 — only the initiator (or a policy-delegated role) may cancel. See `examples-service/src/example-agents/runtime/cancel-callback-server.ts` for a reference implementation.
+
+---
+
+## Verify
+
+1. Launch a scenario that includes your agent.
+2. Watch the runtime logs — your agent's envelopes should show `sender=<your-agent-id>`.
+3. Watch the control-plane's run event feed — no `UNAUTHENTICATED` errors.
+4. If the agent is the initiator: runtime logs show `SessionStart accepted, initiator_sender=<your-agent-id>`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Agent logs `UNAUTHENTICATED` on first `send` | Runtime doesn't know the token | Check step 2 — token and sender in `MACP_AUTH_TOKENS_JSON` must exactly match. Redeploy runtime. |
+| Agent throws `bootstrap.runtime.bearerToken is required` | Token map missing the sender | Check step 3 — add entry to `EXAMPLES_SERVICE_AGENT_TOKENS_JSON`. |
+| Initiator's SessionStart is rejected with `Forbidden` | `can_start_sessions: false` on the runtime identity | Flip it to `true` in the runtime's `MACP_AUTH_TOKENS_JSON` entry. |
+| Agent sends envelopes but they're rejected with `sender does not match identity` | Sender string mismatch | The string in `bootstrap.participant.participantId`, the envelope's `sender` field, and the runtime's identity `sender` field must all be identical byte-for-byte. Check for stray `agent://` prefixes. |
+| Cancel from UI doesn't take effect | Missing `cancelCallback` or unreachable | Verify the callback is exposed from the agent and reachable from the control-plane. Verify `bootstrap.cancelCallback` is populated. |
+
+---
+
+## See also
+
+- `ui-console/plans/direct-agent-auth.md` — full architecture + invariants + RFC justification
+- `schemas/json/macp-run-descriptor.schema.json` — control-plane `POST /runs` contract
+- `schemas/json/macp-agent-bootstrap.schema.json` — agent bootstrap contract
+- `schemas/json/macp-session-metadata.schema.json` — session metadata runtime returns
+- RFC-MACP-0004 §3 (Authentication) + §4 (Authorization) + §11 (Multi-tenancy)
+- RFC-MACP-0001 §7 (Session lifecycle) + §7.2 (Cancellation authority)

--- a/examples/decision-mode-session.json
+++ b/examples/decision-mode-session.json
@@ -25,7 +25,7 @@
         "configuration_version": "runtime-2026.03.02",
         "policy_version": "banking-policy-2026.03",
         "ttl_ms": 15000,
-        "context": "eyJ0cmFuc2FjdGlvbl9hbW91bnQiOiA0ODAwMCwgImNpdHkiOiAiU2FvIFBhdWxvIn0="
+        "context_id": "ctx:txn:TXN-48000-SaoPaulo"
       }
     },
     {

--- a/examples/json/session_start.json
+++ b/examples/json/session_start.json
@@ -17,6 +17,6 @@
     "configuration_version": "runtime-2026.03.01",
     "policy_version": "org-procurement-2026.02",
     "ttl_ms": 900000,
-    "context": "eyJidWRnZXQiOiAxMDAwMH0="
+    "context_id": "ctx:procurement:ocr-pipeline-2026Q1"
   }
 }

--- a/examples/policy-registration-exchange.json
+++ b/examples/policy-registration-exchange.json
@@ -10,7 +10,7 @@
         "description": "Supermajority voting with 2/3 threshold and quorum of 3 participants",
         "schema_version": 1,
         "rules": {
-          "$comment": "Shown as decoded JSON for readability. In proto wire format, this is JSON-encoded bytes (base64 in JSON serialization).",
+          "$comment": "Shown as decoded JSON for readability. In proto wire format, this is a JSON string field.",
           "voting": {
             "algorithm": "supermajority",
             "threshold": 0.67,

--- a/packages/proto-npm/proto/macp/v1/core.proto
+++ b/packages/proto-npm/proto/macp/v1/core.proto
@@ -28,6 +28,8 @@ message RuntimeInfo {
 
 message SessionsCapability {
   bool stream = 1;
+  bool list_sessions = 2;
+  bool watch_sessions = 3;
 }
 
 message CancellationCapability {
@@ -103,8 +105,19 @@ message SessionStartPayload {
   string configuration_version = 4;
   string policy_version = 5;
   int64 ttl_ms = 6;
-  bytes context = 7;
-  repeated Root roots = 8;
+  repeated Root roots = 7;
+
+  // Globally-unique context reference (e.g. "ctx:sha256:<hex>", a URI, or any
+  // opaque string) naming the structured context this session operates within.
+  // The runtime preserves it on SessionMetadata but MUST NOT interpret it;
+  // semantics are defined by the context protocol (CTXM, etc.).
+  string context_id = 8;
+
+  // Generic extension blocks keyed by protocol identifier.
+  // Each value is protocol-specific bytes (typically JSON or sub-proto).
+  // The runtime MUST preserve all entries but MUST NOT depend on them
+  // for core session lifecycle (RFC-MACP-0001 §7.X).
+  map<string, bytes> extensions = 9;
 }
 
 message SessionCancelPayload {
@@ -150,6 +163,12 @@ message SessionMetadata {
   // The sender of the accepted SessionStart message.
   // Used for cancellation authorization and audit.
   string initiator = 11;
+
+  // The context_id from SessionStartPayload, if set. Preserved verbatim.
+  string context_id = 12;
+
+  // Extension keys active on this session (keys only, not values).
+  repeated string extension_keys = 13;
 }
 
 message GetSessionRequest {
@@ -307,6 +326,36 @@ message WatchSignalsResponse {
   Envelope envelope = 1;
 }
 
+// Session lifecycle observation (RFC-MACP-0001 §7.3).
+// Observers subscribe once and receive a notification each time a session
+// is created, resolved, or expired. The first response carries all currently
+// active sessions (initial sync); subsequent responses carry individual
+// lifecycle transitions.
+
+message ListSessionsRequest {}
+
+message ListSessionsResponse {
+  repeated SessionMetadata sessions = 1;
+}
+
+message WatchSessionsRequest {}
+
+message SessionLifecycleEvent {
+  enum EventType {
+    EVENT_TYPE_UNSPECIFIED = 0;
+    EVENT_TYPE_CREATED = 1;
+    EVENT_TYPE_RESOLVED = 2;
+    EVENT_TYPE_EXPIRED = 3;
+  }
+  EventType event_type = 1;
+  SessionMetadata session = 2;
+  int64 observed_at_unix_ms = 3;
+}
+
+message WatchSessionsResponse {
+  SessionLifecycleEvent event = 1;
+}
+
 service MACPRuntimeService {
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -325,6 +374,9 @@ service MACPRuntimeService {
   rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
   // Ambient Signal observation
   rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
+  // Session lifecycle observation (RFC-MACP-0001 §7.3)
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+  rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
   // Governance policy lifecycle (RFC-MACP-0012)
   rpc RegisterPolicy(RegisterPolicyRequest) returns (RegisterPolicyResponse);
   rpc UnregisterPolicy(UnregisterPolicyRequest) returns (UnregisterPolicyResponse);

--- a/packages/proto-npm/proto/macp/v1/policy.proto
+++ b/packages/proto-npm/proto/macp/v1/policy.proto
@@ -17,7 +17,7 @@ message PolicyDescriptor {
   // JSON-encoded governance rules per the target mode's rule schema.
   // The structure of this JSON is defined by the mode-specific rule JSON Schema
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
-  bytes rules = 4;
+  string rules = 4;
 
   // Version of the rule schema used (currently 1).
   uint32 schema_version = 5;

--- a/packages/proto-python/src/macp/v1/core_pb2_grpc.py
+++ b/packages/proto-python/src/macp/v1/core_pb2_grpc.py
@@ -226,7 +226,7 @@ class MACPRuntimeServiceServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def WatchSignals(self, request, context):
-        """Ambient signal observation
+        """Ambient Signal observation
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')

--- a/packages/proto-rust/proto/macp/v1/core.proto
+++ b/packages/proto-rust/proto/macp/v1/core.proto
@@ -28,6 +28,8 @@ message RuntimeInfo {
 
 message SessionsCapability {
   bool stream = 1;
+  bool list_sessions = 2;
+  bool watch_sessions = 3;
 }
 
 message CancellationCapability {
@@ -103,8 +105,19 @@ message SessionStartPayload {
   string configuration_version = 4;
   string policy_version = 5;
   int64 ttl_ms = 6;
-  bytes context = 7;
-  repeated Root roots = 8;
+  repeated Root roots = 7;
+
+  // Globally-unique context reference (e.g. "ctx:sha256:<hex>", a URI, or any
+  // opaque string) naming the structured context this session operates within.
+  // The runtime preserves it on SessionMetadata but MUST NOT interpret it;
+  // semantics are defined by the context protocol (CTXM, etc.).
+  string context_id = 8;
+
+  // Generic extension blocks keyed by protocol identifier.
+  // Each value is protocol-specific bytes (typically JSON or sub-proto).
+  // The runtime MUST preserve all entries but MUST NOT depend on them
+  // for core session lifecycle (RFC-MACP-0001 §7.X).
+  map<string, bytes> extensions = 9;
 }
 
 message SessionCancelPayload {
@@ -150,6 +163,12 @@ message SessionMetadata {
   // The sender of the accepted SessionStart message.
   // Used for cancellation authorization and audit.
   string initiator = 11;
+
+  // The context_id from SessionStartPayload, if set. Preserved verbatim.
+  string context_id = 12;
+
+  // Extension keys active on this session (keys only, not values).
+  repeated string extension_keys = 13;
 }
 
 message GetSessionRequest {
@@ -307,6 +326,36 @@ message WatchSignalsResponse {
   Envelope envelope = 1;
 }
 
+// Session lifecycle observation (RFC-MACP-0001 §7.3).
+// Observers subscribe once and receive a notification each time a session
+// is created, resolved, or expired. The first response carries all currently
+// active sessions (initial sync); subsequent responses carry individual
+// lifecycle transitions.
+
+message ListSessionsRequest {}
+
+message ListSessionsResponse {
+  repeated SessionMetadata sessions = 1;
+}
+
+message WatchSessionsRequest {}
+
+message SessionLifecycleEvent {
+  enum EventType {
+    EVENT_TYPE_UNSPECIFIED = 0;
+    EVENT_TYPE_CREATED = 1;
+    EVENT_TYPE_RESOLVED = 2;
+    EVENT_TYPE_EXPIRED = 3;
+  }
+  EventType event_type = 1;
+  SessionMetadata session = 2;
+  int64 observed_at_unix_ms = 3;
+}
+
+message WatchSessionsResponse {
+  SessionLifecycleEvent event = 1;
+}
+
 service MACPRuntimeService {
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -325,6 +374,9 @@ service MACPRuntimeService {
   rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
   // Ambient Signal observation
   rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
+  // Session lifecycle observation (RFC-MACP-0001 §7.3)
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+  rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
   // Governance policy lifecycle (RFC-MACP-0012)
   rpc RegisterPolicy(RegisterPolicyRequest) returns (RegisterPolicyResponse);
   rpc UnregisterPolicy(UnregisterPolicyRequest) returns (UnregisterPolicyResponse);

--- a/packages/proto-rust/proto/macp/v1/policy.proto
+++ b/packages/proto-rust/proto/macp/v1/policy.proto
@@ -17,7 +17,7 @@ message PolicyDescriptor {
   // JSON-encoded governance rules per the target mode's rule schema.
   // The structure of this JSON is defined by the mode-specific rule JSON Schema
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
-  bytes rules = 4;
+  string rules = 4;
 
   // Version of the rule schema used (currently 1).
   uint32 schema_version = 5;

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -189,8 +189,9 @@ A valid `SessionStart` message consists of an Envelope with a non-empty `session
 - `ttl_ms` (MUST be greater than zero),
 - `participants` (when required by the Mode),
 - `policy_version` (MUST be present in the payload; MAY be empty, in which case the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
-- `context` when present,
-- `roots` when present.
+- `roots` when present,
+- `context_id` when present (see §7.4.1),
+- `extensions` when present (see §7.4.2).
 
 `configuration_version` is an opaque string that identifies a mode-specific configuration profile. Its format and interpretation are implementation-defined and not part of the MACP interoperability contract. Runtimes MUST store the bound `configuration_version` in session metadata for replay integrity.
 
@@ -229,6 +230,32 @@ By default, only the accepted `SessionStart` sender (session initiator) is autho
 `CancelSession` is the client-facing RPC. Upon accepting a `CancelSession` request, the runtime MUST append a `SessionCancel` envelope (with `SessionCancelPayload`) to the session's accepted history as a terminal annotation. `SessionCancel` envelopes MUST NOT be submitted directly via the `Send` RPC; the runtime is the sole emitter.
 
 `CancelSession` is a Core control-plane message. Mode-specific authorization rules (e.g., who can emit which Mode message type) do NOT apply to `CancelSession`. Only the initiator and policy-delegated roles may cancel a session.
+
+### 7.4 Session Context and Extensions
+
+#### 7.4.1 Context Reference
+
+`SessionStartPayload` MAY carry a `context_id` string field naming the structured context this session operates within (e.g., a content-addressed context identifier, a knowledge-base URI, or any opaque reference).
+
+The runtime MUST preserve `context_id` on `SessionMetadata` for the session's lifetime. The runtime MUST NOT interpret, resolve, or validate the value — it is an opaque reference whose semantics are defined by the context protocol in use (e.g., CTXM).
+
+Observers (including control-planes and UIs) MAY use `context_id` for indexing, linking, and display without parsing extension-specific data.
+
+#### 7.4.2 Extension Blocks
+
+`SessionStartPayload` MAY carry a `map<string, bytes> extensions` field containing protocol-specific extension blocks keyed by a globally unique protocol identifier (e.g., `"ctxm"`, `"aitp"`, deployment-specific names).
+
+**Preservation rule (MUST):** The runtime MUST preserve all extension entries in the session's metadata for the session's lifetime.
+
+**Non-dependence rule (MUST):** Core session lifecycle (creation, mode message routing, terminal transitions, cancellation, TTL expiry, deduplication, policy evaluation) MUST NOT depend on any extension block or on `context_id`. A session with empty `context_id` and empty `extensions` MUST behave identically to one with both populated, from the perspective of core protocol mechanics.
+
+**Forward compatibility (MUST):** Runtimes MUST NOT reject a `SessionStart` because it contains unknown extension keys or an unrecognized `context_id` format.
+
+**Extension provider hooks (MAY):** Runtimes MAY register extension providers that receive lifecycle callbacks (session-start, mode-event, session-terminal) for their declared key. Provider errors MUST NOT cause session-lifecycle failures; they SHOULD be logged and MAY be surfaced as ambient `Signal` envelopes for observability.
+
+**Naming convention (RECOMMENDED):** Extension keys SHOULD use dot-separated reverse-domain notation for public protocols (e.g., `ctxm.v1`, `aitp.v1`) and `x-` prefix for deployment-private extensions (e.g., `x-billing`, `x-tracing`).
+
+> **Migration note:** The former opaque `bytes context` field (field 7) has been removed from `SessionStartPayload`. It is superseded by the structured `context_id` (field 8) and `extensions` (field 9) fields. The `roots` field has been renumbered from field 8 to field 7.
 
 ---
 
@@ -304,6 +331,8 @@ If a `StreamSession` receives an invalid or unauthorized envelope, the runtime M
 - `ListRoots` — root listing
 - `WatchRoots` — root change notifications
 - `WatchSignals` — server-streaming RPC that broadcasts accepted Ambient Signal Envelopes in real time. The stream carries only Signals (messages with empty `session_id` and empty `mode`). Signals are ephemeral; there is no built-in backlog or resume mechanism. Clients that disconnect MAY miss Signals.
+- `ListSessions` — returns metadata for all currently active sessions. Advertised by `sessions.list_sessions`.
+- `WatchSessions` — server-streaming RPC that emits `SessionLifecycleEvent` notifications when sessions are created, resolved, or expired. Advertised by `sessions.watch_sessions`.
 
 The proto file also defines extension mode lifecycle RPCs (`ListExtModes`, `RegisterExtMode`, `UnregisterExtMode`, `PromoteMode`); see [RFC-MACP-0002](RFC-MACP-0002-modes.md) for extension mode semantics.
 

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -52,6 +52,9 @@ service MACPRuntimeService {
   rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
   // Ambient Signal observation
   rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
+  // Session lifecycle observation (RFC-MACP-0001 §7.3)
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+  rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
   // Governance policy lifecycle (RFC-MACP-0012)
   rpc RegisterPolicy(RegisterPolicyRequest) returns (RegisterPolicyResponse);
   rpc UnregisterPolicy(UnregisterPolicyRequest) returns (UnregisterPolicyResponse);
@@ -114,11 +117,26 @@ A runtime that supports `WatchSignals` MUST broadcast all accepted Signal envelo
 
 ### 3.5 `GetSession`
 
-`GetSession` returns a `SessionMetadata` snapshot for the given session. The response includes the session's identity, state, timing, and bound version fields (`mode_version`, `configuration_version`, `policy_version`), as well as the current participant list and per-participant activity summaries (`ParticipantActivity`). The `ParticipantActivity` entries provide `participant_id`, `last_message_at_unix_ms`, and `message_count` for each participant that has sent at least one accepted message.
+`GetSession` returns a `SessionMetadata` snapshot for the given session. The response includes the session's identity, state, timing, and bound version fields (`mode_version`, `configuration_version`, `policy_version`), as well as the current participant list, per-participant activity summaries (`ParticipantActivity`), `context_id` (if set at session creation), and `extension_keys` (the keys of any extension blocks bound at session creation). The `ParticipantActivity` entries provide `participant_id`, `last_message_at_unix_ms`, and `message_count` for each participant that has sent at least one accepted message.
 
 ### 3.6 Extension Mode Lifecycle RPCs
 
 `ListExtModes`, `RegisterExtMode`, `UnregisterExtMode`, and `PromoteMode` manage the lifecycle of non-standards-track (extension) coordination modes. These RPCs are implementation-defined surfaces for registering, discovering, and promoting experimental modes. See [RFC-MACP-0002](RFC-MACP-0002-modes.md) for extension mode semantics and the relationship between extension and standards-track modes.
+
+### 3.8 Session Lifecycle Observation RPCs
+
+`ListSessions` and `WatchSessions` provide programmatic session lifecycle observation.
+
+```protobuf
+rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
+```
+
+`ListSessions` returns `SessionMetadata` for all currently known sessions (active and terminal). A runtime MUST advertise `sessions.list_sessions = true` before `ListSessions` can be assumed interoperable.
+
+`WatchSessions` is a server-streaming RPC that emits `SessionLifecycleEvent` notifications. Each event carries an `EventType` (CREATED, RESOLVED, or EXPIRED), the affected `SessionMetadata`, and an `observed_at_unix_ms` timestamp. A runtime MUST advertise `sessions.watch_sessions = true` before `WatchSessions` can be assumed interoperable.
+
+Session lifecycle events are ephemeral — they are not persisted and are not available for replay. Clients that disconnect MAY miss events. Control-planes and UIs SHOULD use `ListSessions` for initial sync and `WatchSessions` for incremental updates.
 
 ### 3.7 Policy Lifecycle RPCs
 

--- a/schemas/json/macp-agent-bootstrap.schema.json
+++ b/schemas/json/macp-agent-bootstrap.schema.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://macp.dev/schemas/macp-agent-bootstrap.schema.json",
+  "title": "MACP Agent Bootstrap Payload",
+  "description": "Canonical schema for the bootstrap payload written to MACP_BOOTSTRAP_FILE before an agent process is spawned. Consumed by the agent at startup to learn its runId, sessionId, runtime address + Bearer token, and — for the initiator agent only — the SessionStart payload and the first kickoff envelope template. See direct-agent-auth architecture (§Invariants).",
+  "type": "object",
+  "required": ["run", "participant", "runtime"],
+  "additionalProperties": true,
+  "properties": {
+    "run": {
+      "type": "object",
+      "required": ["runId", "sessionId"],
+      "additionalProperties": true,
+      "properties": {
+        "runId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Control-plane run identifier."
+        },
+        "sessionId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Pre-allocated session identifier the initiator will bind at SessionStart. Satisfies runtime validation: UUID v4/v7 or base64url 22+ chars.",
+          "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[4|7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[A-Za-z0-9_-]{22,})$"
+        },
+        "traceId": {
+          "type": "string",
+          "description": "Optional OpenTelemetry trace id."
+        }
+      }
+    },
+    "participant": {
+      "type": "object",
+      "required": ["participantId"],
+      "additionalProperties": true,
+      "properties": {
+        "participantId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The agent's sender id. Must match the authenticated identity on the runtime (RFC-MACP-0004 §4)."
+        },
+        "agentId": {
+          "type": "string",
+          "description": "Agent catalog reference (e.g. 'fraud-agent'). May equal participantId."
+        },
+        "displayName": { "type": "string" },
+        "role": { "type": "string" }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "required": ["address", "bearerToken"],
+      "additionalProperties": true,
+      "properties": {
+        "address": {
+          "type": "string",
+          "minLength": 1,
+          "description": "gRPC endpoint of the MACP runtime, e.g. '127.0.0.1:50051' or 'runtime.internal:50051'."
+        },
+        "bearerToken": {
+          "type": "string",
+          "minLength": 1,
+          "description": "This agent's own Bearer token. Must match an identity in the runtime's MACP_AUTH_TOKENS_JSON whose 'sender' equals participant.participantId."
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "If true, use TLS for the gRPC channel. Default true in production per RFC-MACP-0006 §3."
+        },
+        "allowInsecure": {
+          "type": "boolean",
+          "description": "Dev-only escape hatch to permit a plaintext channel. Must be false in production."
+        },
+        "controlPlaneBaseUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "HTTP URL for read-only observability: GET /runs/:id, /runs/:id/events. Not used for envelope emission (agents emit via gRPC)."
+        },
+        "controlPlaneApiKey": {
+          "type": "string",
+          "description": "Optional API key for the control-plane HTTP reads above."
+        }
+      }
+    },
+    "initiator": {
+      "type": "object",
+      "description": "Populated ONLY on the initiator agent's bootstrap. The initiator calls MacpClient.send(SessionStart) with sessionStart, awaits ack, then emits kickoff (when present) as its first mode-scoped envelope.",
+      "required": ["sessionStart"],
+      "additionalProperties": false,
+      "properties": {
+        "sessionStart": {
+          "type": "object",
+          "required": ["intent", "participants", "ttlMs", "modeVersion", "configurationVersion"],
+          "additionalProperties": false,
+          "properties": {
+            "intent": { "type": "string" },
+            "participants": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 },
+              "minItems": 1,
+              "maxItems": 1000,
+              "uniqueItems": true
+            },
+            "ttlMs": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 86400000
+            },
+            "modeVersion": { "type": "string", "minLength": 1 },
+            "configurationVersion": { "type": "string", "minLength": 1 },
+            "policyVersion": { "type": "string" },
+            "context": {
+              "type": "string",
+              "description": "Opaque bytes/blob (base64 / proto-encoded) to embed in SessionStartPayload.context."
+            },
+            "roots": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["uri"],
+                "additionalProperties": false,
+                "properties": {
+                  "uri": { "type": "string", "format": "uri" },
+                  "name": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "kickoff": {
+          "type": "object",
+          "description": "Optional first mode-scoped envelope the initiator emits immediately after SessionStart is accepted (e.g., a Proposal for decision mode, a TaskRequest for task mode). May be absent for modes where the initiator opens the session but any participant may speak first.",
+          "required": ["messageType", "payload"],
+          "additionalProperties": false,
+          "properties": {
+            "messageType": { "type": "string", "minLength": 1 },
+            "payload": {
+              "type": "string",
+              "description": "Pre-encoded payload bytes (base64 / proto-encoded) ready to place in Envelope.payload."
+            }
+          }
+        }
+      }
+    },
+    "cancelCallback": {
+      "type": "object",
+      "description": "Local HTTP endpoint the agent exposes so the control-plane's UI-cancel path (direct-agent-auth Option A) can ask the initiator to call CancelSession on the runtime with its own identity (RFC-MACP-0001 §7.2).",
+      "required": ["host", "port", "path"],
+      "additionalProperties": false,
+      "properties": {
+        "host": { "type": "string", "minLength": 1 },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "path": { "type": "string", "minLength": 1, "pattern": "^/" }
+      }
+    },
+    "session": {
+      "type": "object",
+      "description": "Non-authoritative session-context hints. Used by agent frameworks for display/setup only.",
+      "additionalProperties": true,
+      "properties": {
+        "participants": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "metadata": { "type": "object" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "description": "Scenario metadata surfaced to the agent for framework setup (scenarioRef, modeName, tags, requester). Free-form; opaque to the runtime.",
+      "additionalProperties": true
+    },
+    "agent": {
+      "type": "object",
+      "description": "Framework-specific bootstrap data (manifest, framework name, framework config).",
+      "additionalProperties": true,
+      "properties": {
+        "manifest": { "type": "object" },
+        "framework": { "type": "string" },
+        "frameworkConfig": { "type": "object" }
+      }
+    }
+  }
+}

--- a/schemas/json/macp-envelope.schema.json
+++ b/schemas/json/macp-envelope.schema.json
@@ -282,9 +282,6 @@
           "minimum": 1,
           "description": "Session TTL in milliseconds."
         },
-        "context": {
-          "$ref": "#/$defs/Base64Bytes"
-        },
         "roots": {
           "type": "array",
           "items": {
@@ -293,6 +290,17 @@
         },
         "policy_version": {
           "type": "string"
+        },
+        "context_id": {
+          "type": "string",
+          "description": "Globally-unique context reference (e.g. ctx:sha256:<hex>, a URI, or any opaque string). The runtime preserves it but MUST NOT interpret it."
+        },
+        "extensions": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Base64Bytes"
+          },
+          "description": "Generic extension blocks keyed by protocol identifier. Values are base64-encoded protocol-specific bytes."
         }
       }
     },

--- a/schemas/json/macp-policy-descriptor.schema.json
+++ b/schemas/json/macp-policy-descriptor.schema.json
@@ -21,7 +21,7 @@
     },
     "rules": {
       "type": "object",
-      "description": "Mode-specific governance rules. In protobuf, this is bytes containing JSON."
+      "description": "Mode-specific governance rules. In protobuf, this is a JSON string field."
     },
     "description": {
       "type": "string",

--- a/schemas/json/macp-run-descriptor.schema.json
+++ b/schemas/json/macp-run-descriptor.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://macp.dev/schemas/macp-run-descriptor.schema.json",
+  "title": "MACP Run Descriptor",
+  "description": "Scenario-agnostic execution descriptor posted by a scenario-producing tier (e.g., examples-service) to a control plane's `POST /runs` endpoint. The control plane does not decode scenario semantics (RFC-MACP-0004 §3, direct-agent-auth architecture). It returns {runId, sessionId, ...} and observes the session the initiator agent opens on the runtime.",
+  "type": "object",
+  "required": ["runtime", "session"],
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["live", "sandbox"],
+      "description": "Execution mode. 'replay' is exposed as a separate endpoint."
+    },
+    "runtime": {
+      "type": "object",
+      "required": ["kind"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Runtime provider kind (e.g., 'rust'). Selects the control-plane's runtime provider."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional runtime version pin."
+        }
+      }
+    },
+    "session": {
+      "type": "object",
+      "required": ["modeName", "modeVersion", "configurationVersion", "ttlMs", "participants"],
+      "additionalProperties": false,
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "Optional caller-provided session id. Must satisfy runtime validation: UUID v4/v7 or base64url 22+ chars. If omitted, the control plane allocates a UUID v4 and echoes it in the response.",
+          "pattern": "^([0-9a-f]{8}-[0-9a-f]{4}-[4|7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[A-Za-z0-9_-]{22,})$"
+        },
+        "modeName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical mode identifier (e.g. 'macp.mode.decision.v1'). Opaque to the control plane; bound at SessionStart by the initiator agent."
+        },
+        "modeVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Semantic mode version bound at SessionStart."
+        },
+        "configurationVersion": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Configuration version bound at SessionStart."
+        },
+        "policyVersion": {
+          "type": "string",
+          "description": "Policy identifier bound at SessionStart (RFC-MACP-0012 §6.1). Opaque to the control plane. Empty → runtime resolves to 'policy.default'."
+        },
+        "ttlMs": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 86400000,
+          "description": "Session TTL in milliseconds. Runtime accepts 1..86_400_000 (runtime/src/session.rs)."
+        },
+        "participants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Participant sender id. Plain string; the 'agent://' prefix is a convention, not a protocol requirement (RFC-MACP-0001 §6)."
+              }
+            }
+          },
+          "minItems": 1,
+          "maxItems": 1000,
+          "uniqueItems": true,
+          "description": "Declared participants. Used for audit/projection only; no roles, no per-participant semantics."
+        },
+        "context": {
+          "type": "string",
+          "description": "Optional opaque context blob. Control plane persists it as metadata but does NOT decode it. Initiator agent may embed this verbatim in its SessionStart payload."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Free-form transport-layer metadata (environment label, source tag, cancelCallback coordinates, cancellationDelegated flag). Opaque to the runtime.",
+          "properties": {
+            "cancelCallback": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "HTTP endpoint the control plane calls when the UI triggers cancel (direct-agent-auth Option A — initiator agent forwards CancelSession).",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Callback URL on the initiator agent."
+                },
+                "bearer": {
+                  "type": "string",
+                  "description": "Optional shared-secret Bearer token for the callback."
+                }
+              },
+              "required": ["url"]
+            },
+            "cancellationDelegated": {
+              "type": "boolean",
+              "description": "Option B: when true and the session's policy grants commitment authority to the control-plane identity, the control plane calls CancelSession directly on the runtime instead of the callback (RFC-MACP-0001 §7.2)."
+            }
+          }
+        }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "type": "string",
+          "description": "Optional idempotency key; control plane returns the existing run on 409."
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "UI-facing tags. Scenario-free; no runtime semantics."
+        },
+        "requester": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "actorId": { "type": "string" },
+            "actorType": {
+              "type": "string",
+              "enum": ["user", "service", "system"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/json/macp-session-lifecycle-event.schema.json
+++ b/schemas/json/macp-session-lifecycle-event.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://macp.dev/schemas/macp-session-lifecycle-event.schema.json",
+  "title": "MACP Session Lifecycle Event",
+  "description": "JSON Schema for SessionLifecycleEvent emitted by WatchSessions. See RFC-MACP-0001 Section 7.3 and RFC-MACP-0006 Section 3.8.",
+  "type": "object",
+  "required": [
+    "event_type",
+    "session"
+  ],
+  "properties": {
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "EVENT_TYPE_UNSPECIFIED",
+        "EVENT_TYPE_CREATED",
+        "EVENT_TYPE_RESOLVED",
+        "EVENT_TYPE_EXPIRED"
+      ],
+      "description": "The type of session lifecycle event."
+    },
+    "session": {
+      "$ref": "macp-session-metadata.schema.json",
+      "description": "The session affected by this lifecycle event."
+    },
+    "observed_at_unix_ms": {
+      "type": "integer",
+      "description": "Timestamp when the event was observed (milliseconds since Unix epoch)."
+    }
+  }
+}

--- a/schemas/json/macp-session-lifecycle-event.schema.json
+++ b/schemas/json/macp-session-lifecycle-event.schema.json
@@ -20,8 +20,17 @@
       "description": "The type of session lifecycle event."
     },
     "session": {
-      "$ref": "macp-session-metadata.schema.json",
-      "description": "The session affected by this lifecycle event."
+      "type": "object",
+      "description": "The session affected by this lifecycle event. See macp-session-metadata.schema.json for the full SessionMetadata definition.",
+      "required": ["session_id", "mode", "state"],
+      "properties": {
+        "session_id": { "type": "string" },
+        "mode": { "type": "string" },
+        "state": {
+          "type": "string",
+          "enum": ["SESSION_STATE_UNSPECIFIED", "SESSION_STATE_OPEN", "SESSION_STATE_RESOLVED", "SESSION_STATE_EXPIRED"]
+        }
+      }
     },
     "observed_at_unix_ms": {
       "type": "integer",

--- a/schemas/json/macp-session-metadata.schema.json
+++ b/schemas/json/macp-session-metadata.schema.json
@@ -68,6 +68,15 @@
     "initiator": {
       "type": "string",
       "description": "The sender of the accepted SessionStart message. Used for cancellation authorization and audit."
+    },
+    "context_id": {
+      "type": "string",
+      "description": "The context_id from SessionStartPayload, if set. Preserved verbatim."
+    },
+    "extension_keys": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Extension keys active on this session (keys only, not values)."
     }
   },
   "$defs": {

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -28,6 +28,8 @@ message RuntimeInfo {
 
 message SessionsCapability {
   bool stream = 1;
+  bool list_sessions = 2;
+  bool watch_sessions = 3;
 }
 
 message CancellationCapability {
@@ -103,8 +105,19 @@ message SessionStartPayload {
   string configuration_version = 4;
   string policy_version = 5;
   int64 ttl_ms = 6;
-  bytes context = 7;
-  repeated Root roots = 8;
+  repeated Root roots = 7;
+
+  // Globally-unique context reference (e.g. "ctx:sha256:<hex>", a URI, or any
+  // opaque string) naming the structured context this session operates within.
+  // The runtime preserves it on SessionMetadata but MUST NOT interpret it;
+  // semantics are defined by the context protocol (CTXM, etc.).
+  string context_id = 8;
+
+  // Generic extension blocks keyed by protocol identifier.
+  // Each value is protocol-specific bytes (typically JSON or sub-proto).
+  // The runtime MUST preserve all entries but MUST NOT depend on them
+  // for core session lifecycle (RFC-MACP-0001 §7.X).
+  map<string, bytes> extensions = 9;
 }
 
 message SessionCancelPayload {
@@ -150,6 +163,12 @@ message SessionMetadata {
   // The sender of the accepted SessionStart message.
   // Used for cancellation authorization and audit.
   string initiator = 11;
+
+  // The context_id from SessionStartPayload, if set. Preserved verbatim.
+  string context_id = 12;
+
+  // Extension keys active on this session (keys only, not values).
+  repeated string extension_keys = 13;
 }
 
 message GetSessionRequest {
@@ -307,6 +326,36 @@ message WatchSignalsResponse {
   Envelope envelope = 1;
 }
 
+// Session lifecycle observation (RFC-MACP-0001 §7.3).
+// Observers subscribe once and receive a notification each time a session
+// is created, resolved, or expired. The first response carries all currently
+// active sessions (initial sync); subsequent responses carry individual
+// lifecycle transitions.
+
+message ListSessionsRequest {}
+
+message ListSessionsResponse {
+  repeated SessionMetadata sessions = 1;
+}
+
+message WatchSessionsRequest {}
+
+message SessionLifecycleEvent {
+  enum EventType {
+    EVENT_TYPE_UNSPECIFIED = 0;
+    EVENT_TYPE_CREATED = 1;
+    EVENT_TYPE_RESOLVED = 2;
+    EVENT_TYPE_EXPIRED = 3;
+  }
+  EventType event_type = 1;
+  SessionMetadata session = 2;
+  int64 observed_at_unix_ms = 3;
+}
+
+message WatchSessionsResponse {
+  SessionLifecycleEvent event = 1;
+}
+
 service MACPRuntimeService {
   rpc Initialize(InitializeRequest) returns (InitializeResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -325,6 +374,9 @@ service MACPRuntimeService {
   rpc PromoteMode(PromoteModeRequest) returns (PromoteModeResponse);
   // Ambient Signal observation
   rpc WatchSignals(WatchSignalsRequest) returns (stream WatchSignalsResponse);
+  // Session lifecycle observation (RFC-MACP-0001 §7.3)
+  rpc ListSessions(ListSessionsRequest) returns (ListSessionsResponse);
+  rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
   // Governance policy lifecycle (RFC-MACP-0012)
   rpc RegisterPolicy(RegisterPolicyRequest) returns (RegisterPolicyResponse);
   rpc UnregisterPolicy(UnregisterPolicyRequest) returns (UnregisterPolicyResponse);

--- a/schemas/proto/macp/v1/policy.proto
+++ b/schemas/proto/macp/v1/policy.proto
@@ -17,7 +17,7 @@ message PolicyDescriptor {
   // JSON-encoded governance rules per the target mode's rule schema.
   // The structure of this JSON is defined by the mode-specific rule JSON Schema
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
-  bytes rules = 4;
+  string rules = 4;
 
   // Version of the rule schema used (currently 1).
   uint32 schema_version = 5;

--- a/scripts/check-proto-parity.sh
+++ b/scripts/check-proto-parity.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Proto version parity check (W3a / XR-1).
+#
+# Fails CI when the proto package versions consumed by typescript-sdk and python-sdk
+# fall out of sync with the canonical proto packages in this monorepo.
+#
+# Parity rules:
+#   1. packages/proto-npm/package.json version == packages/proto-python/pyproject.toml version.
+#   2. typescript-sdk accepts the canonical @multiagentcoordinationprotocol/proto version
+#      (via the caret range in its package.json).
+#   3. python-sdk accepts the canonical macp-proto version (via its PEP 440 version range).
+#
+# Exits 0 on parity, 1 on drift with a clear diagnostic.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MONO_ROOT="$(cd "$REPO_ROOT/.." && pwd)"
+
+PROTO_NPM_JSON="$REPO_ROOT/packages/proto-npm/package.json"
+PROTO_PY_TOML="$REPO_ROOT/packages/proto-python/pyproject.toml"
+TS_SDK_JSON="$MONO_ROOT/typescript-sdk/package.json"
+PY_SDK_TOML="$MONO_ROOT/python-sdk/pyproject.toml"
+
+missing=()
+for f in "$PROTO_NPM_JSON" "$PROTO_PY_TOML" "$TS_SDK_JSON" "$PY_SDK_TOML"; do
+  [ -f "$f" ] || missing+=("$f")
+done
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "ERROR: missing files:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+# Canonical proto versions (source of truth).
+proto_npm_version="$(grep -m1 '"version"' "$PROTO_NPM_JSON" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+proto_py_version="$(grep -m1 '^version' "$PROTO_PY_TOML" | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+
+# Consumer-declared ranges.
+ts_sdk_range="$(grep -m1 '@multiagentcoordinationprotocol/proto' "$TS_SDK_JSON" | sed -E 's/.*"@multiagentcoordinationprotocol\/proto"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+# Match a real dependency line (starts with whitespace + quote), not a comment.
+py_sdk_range="$(grep -m1 -E '^[[:space:]]*"macp-proto' "$PY_SDK_TOML" | sed -E 's/.*"macp-proto([^"]*)".*/\1/')"
+
+echo "Canonical proto packages:"
+echo "  packages/proto-npm             @ $proto_npm_version"
+echo "  packages/proto-python          @ $proto_py_version"
+echo ""
+echo "SDK consumer ranges:"
+echo "  typescript-sdk → @multiagentcoordinationprotocol/proto $ts_sdk_range"
+echo "  python-sdk     → macp-proto$py_sdk_range"
+echo ""
+
+fail=0
+
+# Rule 1: the two canonical packages publish the same version.
+if [ "$proto_npm_version" != "$proto_py_version" ]; then
+  echo "FAIL: proto-npm ($proto_npm_version) and proto-python ($proto_py_version) are out of sync." >&2
+  fail=1
+fi
+
+# Rule 2: typescript-sdk caret must start with the canonical version.
+# Accepts "^X.Y.Z" or "X.Y.Z"; anything else is suspicious.
+case "$ts_sdk_range" in
+  "^$proto_npm_version"|"$proto_npm_version")
+    :;;
+  *)
+    echo "FAIL: typescript-sdk proto range ($ts_sdk_range) does not pin canonical $proto_npm_version." >&2
+    fail=1
+    ;;
+esac
+
+# Rule 3: python-sdk range must accept the canonical version.
+# Range looks like ">=0.1.0,<0.2.0" — we check that the lower bound matches canonical.
+lower_bound="$(echo "$py_sdk_range" | sed -E 's/>=([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | tr -d ' ')"
+if [ -z "$lower_bound" ] || [ "$lower_bound" = "$py_sdk_range" ]; then
+  echo "WARN: could not parse python-sdk range lower bound from '$py_sdk_range'. Skipping check." >&2
+elif [ "$lower_bound" != "$proto_py_version" ]; then
+  # Allow the lower bound to be older than canonical (forward-compatible) but warn if it's newer.
+  highest=$(printf '%s\n%s\n' "$lower_bound" "$proto_py_version" | sort -V | tail -1)
+  if [ "$highest" = "$lower_bound" ] && [ "$lower_bound" != "$proto_py_version" ]; then
+    echo "FAIL: python-sdk lower-bound ($lower_bound) is ahead of canonical macp-proto ($proto_py_version)." >&2
+    fail=1
+  fi
+fi
+
+if [ $fail -eq 0 ]; then
+  echo "OK — proto versions are in parity."
+  exit 0
+fi
+
+cat >&2 <<EOF
+
+Proto drift detected.
+
+Fix options:
+  1. Bump the SDK consumer ranges to match the canonical proto package versions.
+  2. Or, publish a new proto-packages release and update proto-npm + proto-python in lockstep
+     (run .github/workflows/publish-proto-packages.yml with the same version on both).
+
+See multiagentcoordinationprotocol/packages/proto-npm/ and /proto-python/ for the canonical
+publish flow. See ui-console/plans/direct-agent-auth.md W3a for rationale.
+EOF
+
+exit 1


### PR DESCRIPTION
## Summary                                                      

  - **SessionStartPayload**: Remove opaque `bytes context` field (field 7), add structured `context_id` (string, field 8) and `extensions` (map<string,bytes>, field 9) 
  for protocol-keyed extension blocks. Renumber `roots` from field 8 to 7.
  - **SessionMetadata**: Add `context_id` (field 12) and `extension_keys` (field 13) so observers can discover context and active extensions without parsing payloads.  
  - **SessionsCapability**: Add `list_sessions` and `watch_sessions` capability flags.                                                                                  
  - **New RPCs**: `ListSessions` (unary) and `WatchSessions` (server-streaming) for programmatic session lifecycle observation, with `SessionLifecycleEvent` message    
  (CREATED/RESOLVED/EXPIRED).                                                                                                                                           
  - **PolicyDescriptor**: Change `bytes rules = 4` to `string rules = 4` — the field is always JSON, `string` is the honest type.                                       
  - **RFC-MACP-0001**: Add §7.4 "Session Context and Extensions" (preservation, non-dependence, forward-compat rules). Update §7.1 field list and §9 RPC listing.       
  - **RFC-MACP-0006**: Add §3.8 "Session Lifecycle Observation RPCs". Update service definition and §3.5 GetSession description.                                        
  - **JSON schemas**: Update envelope, session-metadata, and policy-descriptor schemas. Add new `macp-session-lifecycle-event.schema.json`.                             
  - **Docs**: Update `lifecycle.md` with session observation and context/extensions sections.                                                                           
  - **Examples**: Replace `context` base64 with `context_id` strings in session_start and decision-mode examples.                                                       
                                                                                                                                                                        
  ## Breaking changes (pre-1.0)                                                                                                                                         
                                                                                                                                                                        
  | Proto | Field | Before | After |                                                                                                                                    
  |---|---|---|---|                                               
  | `SessionStartPayload` | `context` | `bytes context = 7` | Removed |                                                                                                 
  | `SessionStartPayload` | `roots` | field 8 | field 7 |         
  | `SessionStartPayload` | `context_id` | — | `string context_id = 8` (new) |                                                                                          
  | `SessionStartPayload` | `extensions` | — | `map<string, bytes> extensions = 9` (new) |                                                                              
  | `PolicyDescriptor` | `rules` | `bytes rules = 4` | `string rules = 4` |                                                                                             
                                                                                                                                                                        
  ## Test plan                                                    
                                                                                                                                                                        
  - [ ] `protoc` compiles all proto files without errors                                                                                                                
  - [ ] `buf lint` passes
  - [ ] JSON schema validation passes for updated examples                                                                                                              
  - [ ] Downstream repos (runtime, SDKs) updated to match new field names         