### PR TITLE
Add passive session subscription, stub-drift guards, and discovery ex…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,33 @@ jobs:
           chmod +x scripts/sync-proto-packages.sh
           ./scripts/sync-proto-packages.sh --check
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install grpcio-tools for stub drift check
+        run: pip install grpcio-tools
+
+      - name: Check Python _pb2_grpc.py stubs for drift
+        run: |
+          echo "Checking committed Python gRPC stubs match canonical protos..."
+          chmod +x scripts/check-python-stubs.sh
+          ./scripts/check-python-stubs.sh
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check Go protobuf stubs for drift
+        run: |
+          echo "Checking committed Go protobuf stubs match canonical protos..."
+          chmod +x scripts/check-go-stubs.sh
+          ./scripts/check-go-stubs.sh
+
       - name: Check SDK proto parity (W3a / direct-agent-auth)
         run: |
           echo "Checking typescript-sdk + python-sdk proto ranges match the canonical packages..."

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help validate validate-all proto-lint proto-compile proto-gen-all json-validate json-schema-validate clean install-tools \
-	gen-go gen-python gen-java gen-kotlin gen-csharp gen-js sync-protos check-proto-sync
+	gen-go gen-python gen-java gen-kotlin gen-csharp gen-js sync-protos check-proto-sync \
+	check-python-stubs check-go-stubs
 
 PROTO_SRC := schemas/proto
 PROTO_FILES := macp/v1/envelope.proto macp/v1/core.proto macp/v1/policy.proto \
@@ -28,8 +29,10 @@ help:
 	@echo "  make proto-gen-all         Generate all languages into their packages"
 	@echo ""
 	@echo "Proto Sync (raw-proto packages):"
-	@echo "  make sync-protos           Copy canonical protos → proto-npm, proto-rust, proto-swift"
-	@echo "  make check-proto-sync      Verify packages match canonical (CI guard)"
+	@echo "  make sync-protos           Copy canonical protos → proto-npm, proto-rust"
+	@echo "  make check-proto-sync      Verify raw-proto packages match canonical (CI guard)"
+	@echo "  make check-python-stubs    Verify committed Python _pb2_grpc.py stubs are current"
+	@echo "  make check-go-stubs        Verify committed Go .pb.go stubs are current"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  make clean                 Remove generated files"
@@ -37,7 +40,7 @@ help:
 	@echo ""
 
 # Validate everything
-validate: json-schema-validate json-validate proto-lint proto-compile check-proto-sync
+validate: json-schema-validate json-validate proto-lint proto-compile check-proto-sync check-python-stubs check-go-stubs
 	@echo "✓ All validations passed"
 
 validate-all: validate proto-gen-all
@@ -72,6 +75,16 @@ sync-protos:
 check-proto-sync:
 	@echo "Checking proto package sync..."
 	@./scripts/sync-proto-packages.sh --check
+
+# Check that committed Python gRPC stubs match a fresh generation (CI guard)
+check-python-stubs:
+	@echo "Checking Python _pb2_grpc.py stubs..."
+	@./scripts/check-python-stubs.sh
+
+# Check that committed Go protobuf stubs match a fresh generation (CI guard)
+check-go-stubs:
+	@echo "Checking Go .pb.go stubs..."
+	@./scripts/check-go-stubs.sh
 
 # Compile protobuf to validate syntax
 proto-compile:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,6 +16,20 @@ This repository includes illustrative transcripts for each standards-track mode 
 | [`examples/policy-decision-session.json`](../examples/policy-decision-session.json) | `macp.mode.decision.v1` | policy-governed Decision Mode with supermajority voting, quorum, and critical-severity veto (RFC-MACP-0012) |
 | [`examples/policy-registration-exchange.json`](../examples/policy-registration-exchange.json) | N/A (gRPC exchange) | dynamic policy registration request and response (RFC-MACP-0012 Section 7) |
 
+## Discovery, lifecycle, and runtime examples
+
+Single-document examples that exercise non-transcript schemas:
+
+| File | Schema | What it shows |
+|------|--------|---------------|
+| [`examples/discovery/agent_manifest.json`](../examples/discovery/agent_manifest.json) | [`macp-agent-manifest.schema.json`](../schemas/json/macp-agent-manifest.schema.json) | agent identity, supported modes, transport endpoints |
+| [`examples/discovery/mode_descriptor.json`](../examples/discovery/mode_descriptor.json) | [`macp-mode-descriptor.schema.json`](../schemas/json/macp-mode-descriptor.schema.json) | mode advertisement with message types and schema URIs |
+| [`examples/discovery/policy_descriptor.json`](../examples/discovery/policy_descriptor.json) | [`macp-policy-descriptor.schema.json`](../schemas/json/macp-policy-descriptor.schema.json) | governance policy advertisement (RFC-MACP-0012) |
+| [`examples/discovery/session_metadata.json`](../examples/discovery/session_metadata.json) | [`macp-session-metadata.schema.json`](../schemas/json/macp-session-metadata.schema.json) | `SessionMetadata` returned by `GetSession` |
+| [`examples/discovery/session_lifecycle_event.json`](../examples/discovery/session_lifecycle_event.json) | [`macp-session-lifecycle-event.schema.json`](../schemas/json/macp-session-lifecycle-event.schema.json) | `SessionLifecycleEvent` emitted by `WatchSessions` |
+| [`examples/discovery/run_descriptor.json`](../examples/discovery/run_descriptor.json) | [`macp-run-descriptor.schema.json`](../schemas/json/macp-run-descriptor.schema.json) | scenario-agnostic run descriptor for a control-plane `POST /runs` |
+| [`examples/discovery/agent_bootstrap.json`](../examples/discovery/agent_bootstrap.json) | [`macp-agent-bootstrap.schema.json`](../schemas/json/macp-agent-bootstrap.schema.json) | bootstrap payload written to `MACP_BOOTSTRAP_FILE` before the initiator agent starts |
+
 ## Example shape
 
 Each transcript is an ordered JSON document with:

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -28,7 +28,7 @@ The authoritative per-message request/ack surface. Use `SendResponse.ack` for st
 
 An optional interactive envelope stream, advertised by `sessions.stream = true`. The stream carries canonical MACP Envelopes only — implementations MUST NOT invent ad-hoc pseudo-envelopes for acks or errors. Once bound to a `session_id`, all subsequent session-scoped envelopes on that stream MUST use the same `session_id`.
 
-`StreamSession` is **not** a replacement for unary `Send` acknowledgements. Clients that need per-message negative acknowledgements SHOULD use `Send`. The base protocol does not define a passive attach/no-op envelope for observing an existing session, and session-scoped `Signal` envelopes are invalid as an attach mechanism. If you need zero-mutation observation, begin streaming before the activity of interest or use a deployment-specific extension outside the base protocol.
+`StreamSession` is **not** a replacement for unary `Send` acknowledgements. Clients that need per-message negative acknowledgements SHOULD use `Send`. Session-scoped `Signal` envelopes are invalid as an attach mechanism. For zero-mutation observation of an existing session, use the passive session subscription form defined in [RFC-MACP-0006 §3.2](../rfcs/RFC-MACP-0006-transport-bindings.md#32-streamsession): send a `StreamSessionRequest` with only `subscribe_session_id` (and optional `after_sequence`) set, and the runtime replays accepted session history and then switches seamlessly to live broadcast on the same stream. A single request MUST NOT set both `envelope` and `subscribe_session_id`; the caller MUST be an authenticated declared participant or an observer identity admitted by deployment policy.
 
 ### `WatchModeRegistry` / `WatchRoots` (Server Streaming)
 

--- a/examples/discovery/agent_bootstrap.json
+++ b/examples/discovery/agent_bootstrap.json
@@ -1,0 +1,47 @@
+{
+  "$comment": "Bootstrap payload written to MACP_BOOTSTRAP_FILE before spawning the initiator agent of a Decision Mode run. See macp-agent-bootstrap.schema.json.",
+  "run": {
+    "runId": "run:checkout-48000:2026-03-02T12:00:00Z",
+    "sessionId": "01JCN7X6Y5P9V4H0A8E0F4J1D2",
+    "traceId": "4bf92f3577b34da6a3ce929d0e0e4736"
+  },
+  "participant": {
+    "participantId": "agent://checkout.orchestrator",
+    "agentId": "checkout-orchestrator",
+    "displayName": "Checkout Orchestrator",
+    "role": "initiator"
+  },
+  "runtime": {
+    "address": "runtime.internal:50051",
+    "bearerToken": "macp-dev-token-REDACTED",
+    "tls": true,
+    "allowInsecure": false,
+    "controlPlaneBaseUrl": "https://control-plane.internal",
+    "controlPlaneApiKey": "cp-key-REDACTED"
+  },
+  "initiator": {
+    "sessionStart": {
+      "intent": "Evaluate high-value transfer",
+      "participants": [
+        "agent://checkout.orchestrator",
+        "agent://fraud",
+        "agent://growth",
+        "agent://compliance"
+      ],
+      "ttlMs": 15000,
+      "modeVersion": "1.0.0",
+      "configurationVersion": "runtime-2026.03.02",
+      "policyVersion": "banking-policy-2026.03",
+      "context": "Y3R4OnR4bjpUWE4tNDgwMDAtU2FvUGF1bG8="
+    },
+    "kickoff": {
+      "messageType": "Proposal",
+      "payload": "CgVwcm9wMRIWUmVxdWlyZSBzdGVwLXVwIHZlcmlmeQ=="
+    }
+  },
+  "cancelCallback": {
+    "host": "checkout-orchestrator.internal",
+    "port": 8080,
+    "path": "/macp/cancel"
+  }
+}

--- a/examples/discovery/run_descriptor.json
+++ b/examples/discovery/run_descriptor.json
@@ -1,0 +1,34 @@
+{
+  "mode": "live",
+  "runtime": {
+    "kind": "rust",
+    "version": "0.4.0"
+  },
+  "session": {
+    "sessionId": "01JCN7X6Y5P9V4H0A8E0F4J1D2",
+    "modeName": "macp.mode.decision.v1",
+    "modeVersion": "1.0.0",
+    "configurationVersion": "runtime-2026.03.02",
+    "policyVersion": "banking-policy-2026.03",
+    "ttlMs": 15000,
+    "participants": [
+      { "id": "agent://checkout.orchestrator" },
+      { "id": "agent://fraud" },
+      { "id": "agent://growth" },
+      { "id": "agent://compliance" }
+    ],
+    "context": "ctx:txn:TXN-48000-SaoPaulo",
+    "metadata": {
+      "environment": "prod",
+      "source": "checkout-service"
+    }
+  },
+  "execution": {
+    "idempotencyKey": "run:checkout-48000:2026-03-02T12:00:00Z",
+    "tags": ["checkout", "fraud-review"],
+    "requester": {
+      "actorId": "svc://checkout",
+      "actorType": "service"
+    }
+  }
+}

--- a/examples/discovery/session_lifecycle_event.json
+++ b/examples/discovery/session_lifecycle_event.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Example SessionLifecycleEvent emitted by WatchSessions when a Decision Mode session is resolved. See RFC-MACP-0001 Section 7.3 and RFC-MACP-0006 Section 3.8.",
+  "event_type": "EVENT_TYPE_RESOLVED",
+  "session": {
+    "session_id": "01JCN7X6Y5P9V4H0A8E0F4J1D2",
+    "mode": "macp.mode.decision.v1",
+    "state": "SESSION_STATE_RESOLVED",
+    "started_at_unix_ms": 1772625600000,
+    "expires_at_unix_ms": 1772625615000,
+    "mode_version": "1.0.0",
+    "configuration_version": "runtime-2026.03.02",
+    "policy_version": "banking-policy-2026.03",
+    "initiator": "agent://checkout.orchestrator"
+  },
+  "observed_at_unix_ms": 1772625611500
+}

--- a/examples/discovery/session_metadata.json
+++ b/examples/discovery/session_metadata.json
@@ -1,0 +1,33 @@
+{
+  "session_id": "01JCN7X6Y5P9V4H0A8E0F4J1D2",
+  "mode": "macp.mode.decision.v1",
+  "state": "SESSION_STATE_OPEN",
+  "started_at_unix_ms": 1772625600000,
+  "expires_at_unix_ms": 1772625615000,
+  "mode_version": "1.0.0",
+  "configuration_version": "runtime-2026.03.02",
+  "policy_version": "banking-policy-2026.03",
+  "participants": [
+    "agent://checkout.orchestrator",
+    "agent://fraud",
+    "agent://growth",
+    "agent://compliance"
+  ],
+  "participant_activity": [
+    {
+      "participant_id": "agent://checkout.orchestrator",
+      "last_message_at_unix_ms": 1772625601200,
+      "message_count": 2
+    },
+    {
+      "participant_id": "agent://fraud",
+      "last_message_at_unix_ms": 1772625602100,
+      "message_count": 1
+    }
+  ],
+  "initiator": "agent://checkout.orchestrator",
+  "context_id": "ctx:txn:TXN-48000-SaoPaulo",
+  "extension_keys": [
+    "ctxm.v1"
+  ]
+}

--- a/packages/proto-go/macp/modes/decision/v1/decision.pb.go
+++ b/packages/proto-go/macp/modes/decision/v1/decision.pb.go
@@ -220,7 +220,7 @@ func (x *ObjectionPayload) GetSeverity() string {
 type VotePayload struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ProposalId    string                 `protobuf:"bytes,1,opt,name=proposal_id,json=proposalId,proto3" json:"proposal_id,omitempty"`
-	Vote          string                 `protobuf:"bytes,2,opt,name=vote,proto3" json:"vote,omitempty"` // approve | reject | abstain
+	Vote          string                 `protobuf:"bytes,2,opt,name=vote,proto3" json:"vote,omitempty"` // APPROVE | REJECT | ABSTAIN
 	Reason        string                 `protobuf:"bytes,3,opt,name=reason,proto3" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/packages/proto-go/macp/modes/task/v1/task.pb.go
+++ b/packages/proto-go/macp/modes/task/v1/task.pb.go
@@ -225,6 +225,7 @@ func (x *TaskRejectPayload) GetReason() string {
 	return ""
 }
 
+// No explicit assignee field; runtime validates authorship via Envelope.sender.
 type TaskUpdatePayload struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	TaskId        string                 `protobuf:"bytes,1,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`

--- a/packages/proto-go/macp/v1/core.pb.go
+++ b/packages/proto-go/macp/v1/core.pb.go
@@ -21,6 +21,58 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type SessionLifecycleEvent_EventType int32
+
+const (
+	SessionLifecycleEvent_EVENT_TYPE_UNSPECIFIED SessionLifecycleEvent_EventType = 0
+	SessionLifecycleEvent_EVENT_TYPE_CREATED     SessionLifecycleEvent_EventType = 1
+	SessionLifecycleEvent_EVENT_TYPE_RESOLVED    SessionLifecycleEvent_EventType = 2
+	SessionLifecycleEvent_EVENT_TYPE_EXPIRED     SessionLifecycleEvent_EventType = 3
+)
+
+// Enum value maps for SessionLifecycleEvent_EventType.
+var (
+	SessionLifecycleEvent_EventType_name = map[int32]string{
+		0: "EVENT_TYPE_UNSPECIFIED",
+		1: "EVENT_TYPE_CREATED",
+		2: "EVENT_TYPE_RESOLVED",
+		3: "EVENT_TYPE_EXPIRED",
+	}
+	SessionLifecycleEvent_EventType_value = map[string]int32{
+		"EVENT_TYPE_UNSPECIFIED": 0,
+		"EVENT_TYPE_CREATED":     1,
+		"EVENT_TYPE_RESOLVED":    2,
+		"EVENT_TYPE_EXPIRED":     3,
+	}
+)
+
+func (x SessionLifecycleEvent_EventType) Enum() *SessionLifecycleEvent_EventType {
+	p := new(SessionLifecycleEvent_EventType)
+	*p = x
+	return p
+}
+
+func (x SessionLifecycleEvent_EventType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (SessionLifecycleEvent_EventType) Descriptor() protoreflect.EnumDescriptor {
+	return file_macp_v1_core_proto_enumTypes[0].Descriptor()
+}
+
+func (SessionLifecycleEvent_EventType) Type() protoreflect.EnumType {
+	return &file_macp_v1_core_proto_enumTypes[0]
+}
+
+func (x SessionLifecycleEvent_EventType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use SessionLifecycleEvent_EventType.Descriptor instead.
+func (SessionLifecycleEvent_EventType) EnumDescriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{56, 0}
+}
+
 type Root struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Uri           string                 `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
@@ -228,6 +280,8 @@ func (x *RuntimeInfo) GetWebsiteUrl() string {
 type SessionsCapability struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Stream        bool                   `protobuf:"varint,1,opt,name=stream,proto3" json:"stream,omitempty"`
+	ListSessions  bool                   `protobuf:"varint,2,opt,name=list_sessions,json=listSessions,proto3" json:"list_sessions,omitempty"`
+	WatchSessions bool                   `protobuf:"varint,3,opt,name=watch_sessions,json=watchSessions,proto3" json:"watch_sessions,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -265,6 +319,20 @@ func (*SessionsCapability) Descriptor() ([]byte, []int) {
 func (x *SessionsCapability) GetStream() bool {
 	if x != nil {
 		return x.Stream
+	}
+	return false
+}
+
+func (x *SessionsCapability) GetListSessions() bool {
+	if x != nil {
+		return x.ListSessions
+	}
+	return false
+}
+
+func (x *SessionsCapability) GetWatchSessions() bool {
+	if x != nil {
+		return x.WatchSessions
 	}
 	return false
 }
@@ -937,10 +1005,19 @@ type SessionStartPayload struct {
 	ConfigurationVersion string                 `protobuf:"bytes,4,opt,name=configuration_version,json=configurationVersion,proto3" json:"configuration_version,omitempty"`
 	PolicyVersion        string                 `protobuf:"bytes,5,opt,name=policy_version,json=policyVersion,proto3" json:"policy_version,omitempty"`
 	TtlMs                int64                  `protobuf:"varint,6,opt,name=ttl_ms,json=ttlMs,proto3" json:"ttl_ms,omitempty"`
-	Context              []byte                 `protobuf:"bytes,7,opt,name=context,proto3" json:"context,omitempty"`
-	Roots                []*Root                `protobuf:"bytes,8,rep,name=roots,proto3" json:"roots,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	Roots                []*Root                `protobuf:"bytes,7,rep,name=roots,proto3" json:"roots,omitempty"`
+	// Globally-unique context reference (e.g. "ctx:sha256:<hex>", a URI, or any
+	// opaque string) naming the structured context this session operates within.
+	// The runtime preserves it on SessionMetadata but MUST NOT interpret it;
+	// semantics are defined by the context protocol (CTXM, etc.).
+	ContextId string `protobuf:"bytes,8,opt,name=context_id,json=contextId,proto3" json:"context_id,omitempty"`
+	// Generic extension blocks keyed by protocol identifier.
+	// Each value is protocol-specific bytes (typically JSON or sub-proto).
+	// The runtime MUST preserve all entries but MUST NOT depend on them
+	// for core session lifecycle (RFC-MACP-0001 §7.X).
+	Extensions    map[string][]byte `protobuf:"bytes,9,rep,name=extensions,proto3" json:"extensions,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SessionStartPayload) Reset() {
@@ -1015,13 +1092,6 @@ func (x *SessionStartPayload) GetTtlMs() int64 {
 	return 0
 }
 
-func (x *SessionStartPayload) GetContext() []byte {
-	if x != nil {
-		return x.Context
-	}
-	return nil
-}
-
 func (x *SessionStartPayload) GetRoots() []*Root {
 	if x != nil {
 		return x.Roots
@@ -1029,10 +1099,25 @@ func (x *SessionStartPayload) GetRoots() []*Root {
 	return nil
 }
 
+func (x *SessionStartPayload) GetContextId() string {
+	if x != nil {
+		return x.ContextId
+	}
+	return ""
+}
+
+func (x *SessionStartPayload) GetExtensions() map[string][]byte {
+	if x != nil {
+		return x.Extensions
+	}
+	return nil
+}
+
 type SessionCancelPayload struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Reason        string                 `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
-	CancelledBy   string                 `protobuf:"bytes,2,opt,name=cancelled_by,json=cancelledBy,proto3" json:"cancelled_by,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Reason string                 `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
+	// Set by the runtime; MUST match the authenticated sender of the CancelSession RPC.
+	CancelledBy   string `protobuf:"bytes,2,opt,name=cancelled_by,json=cancelledBy,proto3" json:"cancelled_by,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1261,7 +1346,11 @@ type SessionMetadata struct {
 	ParticipantActivity  []*ParticipantActivity `protobuf:"bytes,10,rep,name=participant_activity,json=participantActivity,proto3" json:"participant_activity,omitempty"`
 	// The sender of the accepted SessionStart message.
 	// Used for cancellation authorization and audit.
-	Initiator     string `protobuf:"bytes,11,opt,name=initiator,proto3" json:"initiator,omitempty"`
+	Initiator string `protobuf:"bytes,11,opt,name=initiator,proto3" json:"initiator,omitempty"`
+	// The context_id from SessionStartPayload, if set. Preserved verbatim.
+	ContextId string `protobuf:"bytes,12,opt,name=context_id,json=contextId,proto3" json:"context_id,omitempty"`
+	// Extension keys active on this session (keys only, not values).
+	ExtensionKeys []string `protobuf:"bytes,13,rep,name=extension_keys,json=extensionKeys,proto3" json:"extension_keys,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1371,6 +1460,20 @@ func (x *SessionMetadata) GetInitiator() string {
 		return x.Initiator
 	}
 	return ""
+}
+
+func (x *SessionMetadata) GetContextId() string {
+	if x != nil {
+		return x.ContextId
+	}
+	return ""
+}
+
+func (x *SessionMetadata) GetExtensionKeys() []string {
+	if x != nil {
+		return x.ExtensionKeys
+	}
+	return nil
 }
 
 type GetSessionRequest struct {
@@ -2210,10 +2313,19 @@ func (x *SendResponse) GetAck() *Ack {
 // StreamSession carries canonical MACP envelopes only.
 // Standard per-message negative acknowledgements remain the responsibility of Send.
 type StreamSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Envelope      *Envelope              `protobuf:"bytes,1,opt,name=envelope,proto3" json:"envelope,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Envelope *Envelope              `protobuf:"bytes,1,opt,name=envelope,proto3" json:"envelope,omitempty"`
+	// Passive session subscription (RFC-MACP-0006 §3.2). When set without an
+	// envelope, binds the stream to the session's broadcast: the runtime first
+	// replays accepted session history from after_sequence onwards, then
+	// switches seamlessly to live broadcast. The caller MUST be an
+	// authenticated declared participant of the session or an observer
+	// identity admitted by deployment policy (RFC-MACP-0004 §4). A single
+	// request MUST NOT set both envelope and subscribe_session_id.
+	SubscribeSessionId string `protobuf:"bytes,2,opt,name=subscribe_session_id,json=subscribeSessionId,proto3" json:"subscribe_session_id,omitempty"`
+	AfterSequence      uint64 `protobuf:"varint,3,opt,name=after_sequence,json=afterSequence,proto3" json:"after_sequence,omitempty"` // 0 = replay from session start
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *StreamSessionRequest) Reset() {
@@ -2253,9 +2365,27 @@ func (x *StreamSessionRequest) GetEnvelope() *Envelope {
 	return nil
 }
 
+func (x *StreamSessionRequest) GetSubscribeSessionId() string {
+	if x != nil {
+		return x.SubscribeSessionId
+	}
+	return ""
+}
+
+func (x *StreamSessionRequest) GetAfterSequence() uint64 {
+	if x != nil {
+		return x.AfterSequence
+	}
+	return 0
+}
+
 type StreamSessionResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Envelope      *Envelope              `protobuf:"bytes,1,opt,name=envelope,proto3" json:"envelope,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Response:
+	//
+	//	*StreamSessionResponse_Envelope
+	//	*StreamSessionResponse_Error
+	Response      isStreamSessionResponse_Response `protobuf_oneof:"response"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2290,12 +2420,46 @@ func (*StreamSessionResponse) Descriptor() ([]byte, []int) {
 	return file_macp_v1_core_proto_rawDescGZIP(), []int{37}
 }
 
-func (x *StreamSessionResponse) GetEnvelope() *Envelope {
+func (x *StreamSessionResponse) GetResponse() isStreamSessionResponse_Response {
 	if x != nil {
-		return x.Envelope
+		return x.Response
 	}
 	return nil
 }
+
+func (x *StreamSessionResponse) GetEnvelope() *Envelope {
+	if x != nil {
+		if x, ok := x.Response.(*StreamSessionResponse_Envelope); ok {
+			return x.Envelope
+		}
+	}
+	return nil
+}
+
+func (x *StreamSessionResponse) GetError() *MACPError {
+	if x != nil {
+		if x, ok := x.Response.(*StreamSessionResponse_Error); ok {
+			return x.Error
+		}
+	}
+	return nil
+}
+
+type isStreamSessionResponse_Response interface {
+	isStreamSessionResponse_Response()
+}
+
+type StreamSessionResponse_Envelope struct {
+	Envelope *Envelope `protobuf:"bytes,1,opt,name=envelope,proto3,oneof"`
+}
+
+type StreamSessionResponse_Error struct {
+	Error *MACPError `protobuf:"bytes,2,opt,name=error,proto3,oneof"` // Application-level validation error; stream remains open.
+}
+
+func (*StreamSessionResponse_Envelope) isStreamSessionResponse_Response() {}
+
+func (*StreamSessionResponse_Error) isStreamSessionResponse_Response() {}
 
 type GetSessionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2984,6 +3148,226 @@ func (x *WatchSignalsResponse) GetEnvelope() *Envelope {
 	return nil
 }
 
+type ListSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsRequest) Reset() {
+	*x = ListSessionsRequest{}
+	mi := &file_macp_v1_core_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsRequest) ProtoMessage() {}
+
+func (x *ListSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_macp_v1_core_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsRequest.ProtoReflect.Descriptor instead.
+func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{53}
+}
+
+type ListSessionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Sessions      []*SessionMetadata     `protobuf:"bytes,1,rep,name=sessions,proto3" json:"sessions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSessionsResponse) Reset() {
+	*x = ListSessionsResponse{}
+	mi := &file_macp_v1_core_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSessionsResponse) ProtoMessage() {}
+
+func (x *ListSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_macp_v1_core_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSessionsResponse.ProtoReflect.Descriptor instead.
+func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *ListSessionsResponse) GetSessions() []*SessionMetadata {
+	if x != nil {
+		return x.Sessions
+	}
+	return nil
+}
+
+type WatchSessionsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WatchSessionsRequest) Reset() {
+	*x = WatchSessionsRequest{}
+	mi := &file_macp_v1_core_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WatchSessionsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WatchSessionsRequest) ProtoMessage() {}
+
+func (x *WatchSessionsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_macp_v1_core_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WatchSessionsRequest.ProtoReflect.Descriptor instead.
+func (*WatchSessionsRequest) Descriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{55}
+}
+
+type SessionLifecycleEvent struct {
+	state            protoimpl.MessageState          `protogen:"open.v1"`
+	EventType        SessionLifecycleEvent_EventType `protobuf:"varint,1,opt,name=event_type,json=eventType,proto3,enum=macp.v1.SessionLifecycleEvent_EventType" json:"event_type,omitempty"`
+	Session          *SessionMetadata                `protobuf:"bytes,2,opt,name=session,proto3" json:"session,omitempty"`
+	ObservedAtUnixMs int64                           `protobuf:"varint,3,opt,name=observed_at_unix_ms,json=observedAtUnixMs,proto3" json:"observed_at_unix_ms,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *SessionLifecycleEvent) Reset() {
+	*x = SessionLifecycleEvent{}
+	mi := &file_macp_v1_core_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SessionLifecycleEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SessionLifecycleEvent) ProtoMessage() {}
+
+func (x *SessionLifecycleEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_macp_v1_core_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SessionLifecycleEvent.ProtoReflect.Descriptor instead.
+func (*SessionLifecycleEvent) Descriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *SessionLifecycleEvent) GetEventType() SessionLifecycleEvent_EventType {
+	if x != nil {
+		return x.EventType
+	}
+	return SessionLifecycleEvent_EVENT_TYPE_UNSPECIFIED
+}
+
+func (x *SessionLifecycleEvent) GetSession() *SessionMetadata {
+	if x != nil {
+		return x.Session
+	}
+	return nil
+}
+
+func (x *SessionLifecycleEvent) GetObservedAtUnixMs() int64 {
+	if x != nil {
+		return x.ObservedAtUnixMs
+	}
+	return 0
+}
+
+type WatchSessionsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Event         *SessionLifecycleEvent `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WatchSessionsResponse) Reset() {
+	*x = WatchSessionsResponse{}
+	mi := &file_macp_v1_core_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WatchSessionsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WatchSessionsResponse) ProtoMessage() {}
+
+func (x *WatchSessionsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_macp_v1_core_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WatchSessionsResponse.ProtoReflect.Descriptor instead.
+func (*WatchSessionsResponse) Descriptor() ([]byte, []int) {
+	return file_macp_v1_core_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *WatchSessionsResponse) GetEvent() *SessionLifecycleEvent {
+	if x != nil {
+		return x.Event
+	}
+	return nil
+}
+
 var File_macp_v1_core_proto protoreflect.FileDescriptor
 
 const file_macp_v1_core_proto_rawDesc = "" +
@@ -3006,9 +3390,11 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x12 \n" +
 	"\vdescription\x18\x04 \x01(\tR\vdescription\x12\x1f\n" +
 	"\vwebsite_url\x18\x05 \x01(\tR\n" +
-	"websiteUrl\",\n" +
+	"websiteUrl\"x\n" +
 	"\x12SessionsCapability\x12\x16\n" +
-	"\x06stream\x18\x01 \x01(\bR\x06stream\"?\n" +
+	"\x06stream\x18\x01 \x01(\bR\x06stream\x12#\n" +
+	"\rlist_sessions\x18\x02 \x01(\bR\flistSessions\x12%\n" +
+	"\x0ewatch_sessions\x18\x03 \x01(\bR\rwatchSessions\"?\n" +
 	"\x16CancellationCapability\x12%\n" +
 	"\x0ecancel_session\x18\x01 \x01(\bR\rcancelSession\"0\n" +
 	"\x12ProgressCapability\x12\x1a\n" +
@@ -3061,16 +3447,23 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\bprogress\x18\x02 \x01(\x01R\bprogress\x12\x14\n" +
 	"\x05total\x18\x03 \x01(\x01R\x05total\x12\x18\n" +
 	"\amessage\x18\x04 \x01(\tR\amessage\x12*\n" +
-	"\x11target_message_id\x18\x05 \x01(\tR\x0ftargetMessageId\"\xa6\x02\n" +
+	"\x11target_message_id\x18\x05 \x01(\tR\x0ftargetMessageId\"\xb8\x03\n" +
 	"\x13SessionStartPayload\x12\x16\n" +
 	"\x06intent\x18\x01 \x01(\tR\x06intent\x12\"\n" +
 	"\fparticipants\x18\x02 \x03(\tR\fparticipants\x12!\n" +
 	"\fmode_version\x18\x03 \x01(\tR\vmodeVersion\x123\n" +
 	"\x15configuration_version\x18\x04 \x01(\tR\x14configurationVersion\x12%\n" +
 	"\x0epolicy_version\x18\x05 \x01(\tR\rpolicyVersion\x12\x15\n" +
-	"\x06ttl_ms\x18\x06 \x01(\x03R\x05ttlMs\x12\x18\n" +
-	"\acontext\x18\a \x01(\fR\acontext\x12#\n" +
-	"\x05roots\x18\b \x03(\v2\r.macp.v1.RootR\x05roots\"Q\n" +
+	"\x06ttl_ms\x18\x06 \x01(\x03R\x05ttlMs\x12#\n" +
+	"\x05roots\x18\a \x03(\v2\r.macp.v1.RootR\x05roots\x12\x1d\n" +
+	"\n" +
+	"context_id\x18\b \x01(\tR\tcontextId\x12L\n" +
+	"\n" +
+	"extensions\x18\t \x03(\v2,.macp.v1.SessionStartPayload.ExtensionsEntryR\n" +
+	"extensions\x1a=\n" +
+	"\x0fExtensionsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"Q\n" +
 	"\x14SessionCancelPayload\x12\x16\n" +
 	"\x06reason\x18\x01 \x01(\tR\x06reason\x12!\n" +
 	"\fcancelled_by\x18\x02 \x01(\tR\vcancelledBy\"\xbb\x02\n" +
@@ -3086,7 +3479,7 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\x13ParticipantActivity\x12%\n" +
 	"\x0eparticipant_id\x18\x01 \x01(\tR\rparticipantId\x124\n" +
 	"\x17last_message_at_unix_ms\x18\x02 \x01(\x03R\x13lastMessageAtUnixMs\x12#\n" +
-	"\rmessage_count\x18\x03 \x01(\rR\fmessageCount\"\xdd\x03\n" +
+	"\rmessage_count\x18\x03 \x01(\rR\fmessageCount\"\xa3\x04\n" +
 	"\x0fSessionMetadata\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x12\n" +
@@ -3100,7 +3493,10 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\fparticipants\x18\t \x03(\tR\fparticipants\x12O\n" +
 	"\x14participant_activity\x18\n" +
 	" \x03(\v2\x1c.macp.v1.ParticipantActivityR\x13participantActivity\x12\x1c\n" +
-	"\tinitiator\x18\v \x01(\tR\tinitiator\"2\n" +
+	"\tinitiator\x18\v \x01(\tR\tinitiator\x12\x1d\n" +
+	"\n" +
+	"context_id\x18\f \x01(\tR\tcontextId\x12%\n" +
+	"\x0eextension_keys\x18\r \x03(\tR\rextensionKeys\"2\n" +
 	"\x11GetSessionRequest\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"M\n" +
@@ -3160,11 +3556,16 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\vSendRequest\x12-\n" +
 	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope\".\n" +
 	"\fSendResponse\x12\x1e\n" +
-	"\x03ack\x18\x01 \x01(\v2\f.macp.v1.AckR\x03ack\"E\n" +
+	"\x03ack\x18\x01 \x01(\v2\f.macp.v1.AckR\x03ack\"\x9e\x01\n" +
 	"\x14StreamSessionRequest\x12-\n" +
-	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope\"F\n" +
-	"\x15StreamSessionResponse\x12-\n" +
-	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope\"J\n" +
+	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope\x120\n" +
+	"\x14subscribe_session_id\x18\x02 \x01(\tR\x12subscribeSessionId\x12%\n" +
+	"\x0eafter_sequence\x18\x03 \x01(\x04R\rafterSequence\"\x80\x01\n" +
+	"\x15StreamSessionResponse\x12/\n" +
+	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeH\x00R\benvelope\x12*\n" +
+	"\x05error\x18\x02 \x01(\v2\x12.macp.v1.MACPErrorH\x00R\x05errorB\n" +
+	"\n" +
+	"\bresponse\"J\n" +
 	"\x12GetSessionResponse\x124\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x18.macp.v1.SessionMetadataR\bmetadata\"7\n" +
 	"\x15CancelSessionResponse\x12\x1e\n" +
@@ -3197,7 +3598,23 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\x04mode\x18\x03 \x01(\tR\x04mode\"\x15\n" +
 	"\x13WatchSignalsRequest\"E\n" +
 	"\x14WatchSignalsResponse\x12-\n" +
-	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope2\x9b\f\n" +
+	"\benvelope\x18\x01 \x01(\v2\x11.macp.v1.EnvelopeR\benvelope\"\x15\n" +
+	"\x13ListSessionsRequest\"L\n" +
+	"\x14ListSessionsResponse\x124\n" +
+	"\bsessions\x18\x01 \x03(\v2\x18.macp.v1.SessionMetadataR\bsessions\"\x16\n" +
+	"\x14WatchSessionsRequest\"\xb5\x02\n" +
+	"\x15SessionLifecycleEvent\x12G\n" +
+	"\n" +
+	"event_type\x18\x01 \x01(\x0e2(.macp.v1.SessionLifecycleEvent.EventTypeR\teventType\x122\n" +
+	"\asession\x18\x02 \x01(\v2\x18.macp.v1.SessionMetadataR\asession\x12-\n" +
+	"\x13observed_at_unix_ms\x18\x03 \x01(\x03R\x10observedAtUnixMs\"p\n" +
+	"\tEventType\x12\x1a\n" +
+	"\x16EVENT_TYPE_UNSPECIFIED\x10\x00\x12\x16\n" +
+	"\x12EVENT_TYPE_CREATED\x10\x01\x12\x17\n" +
+	"\x13EVENT_TYPE_RESOLVED\x10\x02\x12\x16\n" +
+	"\x12EVENT_TYPE_EXPIRED\x10\x03\"M\n" +
+	"\x15WatchSessionsResponse\x124\n" +
+	"\x05event\x18\x01 \x01(\v2\x1e.macp.v1.SessionLifecycleEventR\x05event2\xba\r\n" +
 	"\x12MACPRuntimeService\x12E\n" +
 	"\n" +
 	"Initialize\x12\x1a.macp.v1.InitializeRequest\x1a\x1b.macp.v1.InitializeResponse\x123\n" +
@@ -3216,7 +3633,9 @@ const file_macp_v1_core_proto_rawDesc = "" +
 	"\x0fRegisterExtMode\x12\x1f.macp.v1.RegisterExtModeRequest\x1a .macp.v1.RegisterExtModeResponse\x12Z\n" +
 	"\x11UnregisterExtMode\x12!.macp.v1.UnregisterExtModeRequest\x1a\".macp.v1.UnregisterExtModeResponse\x12H\n" +
 	"\vPromoteMode\x12\x1b.macp.v1.PromoteModeRequest\x1a\x1c.macp.v1.PromoteModeResponse\x12M\n" +
-	"\fWatchSignals\x12\x1c.macp.v1.WatchSignalsRequest\x1a\x1d.macp.v1.WatchSignalsResponse0\x01\x12Q\n" +
+	"\fWatchSignals\x12\x1c.macp.v1.WatchSignalsRequest\x1a\x1d.macp.v1.WatchSignalsResponse0\x01\x12K\n" +
+	"\fListSessions\x12\x1c.macp.v1.ListSessionsRequest\x1a\x1d.macp.v1.ListSessionsResponse\x12P\n" +
+	"\rWatchSessions\x12\x1d.macp.v1.WatchSessionsRequest\x1a\x1e.macp.v1.WatchSessionsResponse0\x01\x12Q\n" +
 	"\x0eRegisterPolicy\x12\x1e.macp.v1.RegisterPolicyRequest\x1a\x1f.macp.v1.RegisterPolicyResponse\x12W\n" +
 	"\x10UnregisterPolicy\x12 .macp.v1.UnregisterPolicyRequest\x1a!.macp.v1.UnregisterPolicyResponse\x12B\n" +
 	"\tGetPolicy\x12\x19.macp.v1.GetPolicyRequest\x1a\x1a.macp.v1.GetPolicyResponse\x12K\n" +
@@ -3236,160 +3655,179 @@ func file_macp_v1_core_proto_rawDescGZIP() []byte {
 	return file_macp_v1_core_proto_rawDescData
 }
 
-var file_macp_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 57)
+var file_macp_v1_core_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_macp_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 63)
 var file_macp_v1_core_proto_goTypes = []any{
-	(*Root)(nil),                      // 0: macp.v1.Root
-	(*ClientInfo)(nil),                // 1: macp.v1.ClientInfo
-	(*RuntimeInfo)(nil),               // 2: macp.v1.RuntimeInfo
-	(*SessionsCapability)(nil),        // 3: macp.v1.SessionsCapability
-	(*CancellationCapability)(nil),    // 4: macp.v1.CancellationCapability
-	(*ProgressCapability)(nil),        // 5: macp.v1.ProgressCapability
-	(*ManifestCapability)(nil),        // 6: macp.v1.ManifestCapability
-	(*ModeRegistryCapability)(nil),    // 7: macp.v1.ModeRegistryCapability
-	(*RootsCapability)(nil),           // 8: macp.v1.RootsCapability
-	(*ExperimentalCapabilities)(nil),  // 9: macp.v1.ExperimentalCapabilities
-	(*Capabilities)(nil),              // 10: macp.v1.Capabilities
-	(*InitializeRequest)(nil),         // 11: macp.v1.InitializeRequest
-	(*InitializeResponse)(nil),        // 12: macp.v1.InitializeResponse
-	(*SignalPayload)(nil),             // 13: macp.v1.SignalPayload
-	(*ProgressPayload)(nil),           // 14: macp.v1.ProgressPayload
-	(*SessionStartPayload)(nil),       // 15: macp.v1.SessionStartPayload
-	(*SessionCancelPayload)(nil),      // 16: macp.v1.SessionCancelPayload
-	(*CommitmentPayload)(nil),         // 17: macp.v1.CommitmentPayload
-	(*ParticipantActivity)(nil),       // 18: macp.v1.ParticipantActivity
-	(*SessionMetadata)(nil),           // 19: macp.v1.SessionMetadata
-	(*GetSessionRequest)(nil),         // 20: macp.v1.GetSessionRequest
-	(*CancelSessionRequest)(nil),      // 21: macp.v1.CancelSessionRequest
-	(*GetManifestRequest)(nil),        // 22: macp.v1.GetManifestRequest
-	(*TransportEndpoint)(nil),         // 23: macp.v1.TransportEndpoint
-	(*AgentManifest)(nil),             // 24: macp.v1.AgentManifest
-	(*ModeDescriptor)(nil),            // 25: macp.v1.ModeDescriptor
-	(*ListModesRequest)(nil),          // 26: macp.v1.ListModesRequest
-	(*ListModesResponse)(nil),         // 27: macp.v1.ListModesResponse
-	(*ListRootsRequest)(nil),          // 28: macp.v1.ListRootsRequest
-	(*ListRootsResponse)(nil),         // 29: macp.v1.ListRootsResponse
-	(*WatchModeRegistryRequest)(nil),  // 30: macp.v1.WatchModeRegistryRequest
-	(*WatchRootsRequest)(nil),         // 31: macp.v1.WatchRootsRequest
-	(*RegistryChanged)(nil),           // 32: macp.v1.RegistryChanged
-	(*RootsChanged)(nil),              // 33: macp.v1.RootsChanged
-	(*SendRequest)(nil),               // 34: macp.v1.SendRequest
-	(*SendResponse)(nil),              // 35: macp.v1.SendResponse
-	(*StreamSessionRequest)(nil),      // 36: macp.v1.StreamSessionRequest
-	(*StreamSessionResponse)(nil),     // 37: macp.v1.StreamSessionResponse
-	(*GetSessionResponse)(nil),        // 38: macp.v1.GetSessionResponse
-	(*CancelSessionResponse)(nil),     // 39: macp.v1.CancelSessionResponse
-	(*GetManifestResponse)(nil),       // 40: macp.v1.GetManifestResponse
-	(*WatchModeRegistryResponse)(nil), // 41: macp.v1.WatchModeRegistryResponse
-	(*WatchRootsResponse)(nil),        // 42: macp.v1.WatchRootsResponse
-	(*ListExtModesRequest)(nil),       // 43: macp.v1.ListExtModesRequest
-	(*ListExtModesResponse)(nil),      // 44: macp.v1.ListExtModesResponse
-	(*RegisterExtModeRequest)(nil),    // 45: macp.v1.RegisterExtModeRequest
-	(*RegisterExtModeResponse)(nil),   // 46: macp.v1.RegisterExtModeResponse
-	(*UnregisterExtModeRequest)(nil),  // 47: macp.v1.UnregisterExtModeRequest
-	(*UnregisterExtModeResponse)(nil), // 48: macp.v1.UnregisterExtModeResponse
-	(*PromoteModeRequest)(nil),        // 49: macp.v1.PromoteModeRequest
-	(*PromoteModeResponse)(nil),       // 50: macp.v1.PromoteModeResponse
-	(*WatchSignalsRequest)(nil),       // 51: macp.v1.WatchSignalsRequest
-	(*WatchSignalsResponse)(nil),      // 52: macp.v1.WatchSignalsResponse
-	nil,                               // 53: macp.v1.ExperimentalCapabilities.FeaturesEntry
-	nil,                               // 54: macp.v1.TransportEndpoint.MetadataEntry
-	nil,                               // 55: macp.v1.AgentManifest.MetadataEntry
-	nil,                               // 56: macp.v1.ModeDescriptor.SchemaUrisEntry
-	(*PolicyRegistryCapability)(nil),  // 57: macp.v1.PolicyRegistryCapability
-	(SessionState)(0),                 // 58: macp.v1.SessionState
-	(*Envelope)(nil),                  // 59: macp.v1.Envelope
-	(*Ack)(nil),                       // 60: macp.v1.Ack
-	(*RegisterPolicyRequest)(nil),     // 61: macp.v1.RegisterPolicyRequest
-	(*UnregisterPolicyRequest)(nil),   // 62: macp.v1.UnregisterPolicyRequest
-	(*GetPolicyRequest)(nil),          // 63: macp.v1.GetPolicyRequest
-	(*ListPoliciesRequest)(nil),       // 64: macp.v1.ListPoliciesRequest
-	(*WatchPoliciesRequest)(nil),      // 65: macp.v1.WatchPoliciesRequest
-	(*RegisterPolicyResponse)(nil),    // 66: macp.v1.RegisterPolicyResponse
-	(*UnregisterPolicyResponse)(nil),  // 67: macp.v1.UnregisterPolicyResponse
-	(*GetPolicyResponse)(nil),         // 68: macp.v1.GetPolicyResponse
-	(*ListPoliciesResponse)(nil),      // 69: macp.v1.ListPoliciesResponse
-	(*WatchPoliciesResponse)(nil),     // 70: macp.v1.WatchPoliciesResponse
+	(SessionLifecycleEvent_EventType)(0), // 0: macp.v1.SessionLifecycleEvent.EventType
+	(*Root)(nil),                         // 1: macp.v1.Root
+	(*ClientInfo)(nil),                   // 2: macp.v1.ClientInfo
+	(*RuntimeInfo)(nil),                  // 3: macp.v1.RuntimeInfo
+	(*SessionsCapability)(nil),           // 4: macp.v1.SessionsCapability
+	(*CancellationCapability)(nil),       // 5: macp.v1.CancellationCapability
+	(*ProgressCapability)(nil),           // 6: macp.v1.ProgressCapability
+	(*ManifestCapability)(nil),           // 7: macp.v1.ManifestCapability
+	(*ModeRegistryCapability)(nil),       // 8: macp.v1.ModeRegistryCapability
+	(*RootsCapability)(nil),              // 9: macp.v1.RootsCapability
+	(*ExperimentalCapabilities)(nil),     // 10: macp.v1.ExperimentalCapabilities
+	(*Capabilities)(nil),                 // 11: macp.v1.Capabilities
+	(*InitializeRequest)(nil),            // 12: macp.v1.InitializeRequest
+	(*InitializeResponse)(nil),           // 13: macp.v1.InitializeResponse
+	(*SignalPayload)(nil),                // 14: macp.v1.SignalPayload
+	(*ProgressPayload)(nil),              // 15: macp.v1.ProgressPayload
+	(*SessionStartPayload)(nil),          // 16: macp.v1.SessionStartPayload
+	(*SessionCancelPayload)(nil),         // 17: macp.v1.SessionCancelPayload
+	(*CommitmentPayload)(nil),            // 18: macp.v1.CommitmentPayload
+	(*ParticipantActivity)(nil),          // 19: macp.v1.ParticipantActivity
+	(*SessionMetadata)(nil),              // 20: macp.v1.SessionMetadata
+	(*GetSessionRequest)(nil),            // 21: macp.v1.GetSessionRequest
+	(*CancelSessionRequest)(nil),         // 22: macp.v1.CancelSessionRequest
+	(*GetManifestRequest)(nil),           // 23: macp.v1.GetManifestRequest
+	(*TransportEndpoint)(nil),            // 24: macp.v1.TransportEndpoint
+	(*AgentManifest)(nil),                // 25: macp.v1.AgentManifest
+	(*ModeDescriptor)(nil),               // 26: macp.v1.ModeDescriptor
+	(*ListModesRequest)(nil),             // 27: macp.v1.ListModesRequest
+	(*ListModesResponse)(nil),            // 28: macp.v1.ListModesResponse
+	(*ListRootsRequest)(nil),             // 29: macp.v1.ListRootsRequest
+	(*ListRootsResponse)(nil),            // 30: macp.v1.ListRootsResponse
+	(*WatchModeRegistryRequest)(nil),     // 31: macp.v1.WatchModeRegistryRequest
+	(*WatchRootsRequest)(nil),            // 32: macp.v1.WatchRootsRequest
+	(*RegistryChanged)(nil),              // 33: macp.v1.RegistryChanged
+	(*RootsChanged)(nil),                 // 34: macp.v1.RootsChanged
+	(*SendRequest)(nil),                  // 35: macp.v1.SendRequest
+	(*SendResponse)(nil),                 // 36: macp.v1.SendResponse
+	(*StreamSessionRequest)(nil),         // 37: macp.v1.StreamSessionRequest
+	(*StreamSessionResponse)(nil),        // 38: macp.v1.StreamSessionResponse
+	(*GetSessionResponse)(nil),           // 39: macp.v1.GetSessionResponse
+	(*CancelSessionResponse)(nil),        // 40: macp.v1.CancelSessionResponse
+	(*GetManifestResponse)(nil),          // 41: macp.v1.GetManifestResponse
+	(*WatchModeRegistryResponse)(nil),    // 42: macp.v1.WatchModeRegistryResponse
+	(*WatchRootsResponse)(nil),           // 43: macp.v1.WatchRootsResponse
+	(*ListExtModesRequest)(nil),          // 44: macp.v1.ListExtModesRequest
+	(*ListExtModesResponse)(nil),         // 45: macp.v1.ListExtModesResponse
+	(*RegisterExtModeRequest)(nil),       // 46: macp.v1.RegisterExtModeRequest
+	(*RegisterExtModeResponse)(nil),      // 47: macp.v1.RegisterExtModeResponse
+	(*UnregisterExtModeRequest)(nil),     // 48: macp.v1.UnregisterExtModeRequest
+	(*UnregisterExtModeResponse)(nil),    // 49: macp.v1.UnregisterExtModeResponse
+	(*PromoteModeRequest)(nil),           // 50: macp.v1.PromoteModeRequest
+	(*PromoteModeResponse)(nil),          // 51: macp.v1.PromoteModeResponse
+	(*WatchSignalsRequest)(nil),          // 52: macp.v1.WatchSignalsRequest
+	(*WatchSignalsResponse)(nil),         // 53: macp.v1.WatchSignalsResponse
+	(*ListSessionsRequest)(nil),          // 54: macp.v1.ListSessionsRequest
+	(*ListSessionsResponse)(nil),         // 55: macp.v1.ListSessionsResponse
+	(*WatchSessionsRequest)(nil),         // 56: macp.v1.WatchSessionsRequest
+	(*SessionLifecycleEvent)(nil),        // 57: macp.v1.SessionLifecycleEvent
+	(*WatchSessionsResponse)(nil),        // 58: macp.v1.WatchSessionsResponse
+	nil,                                  // 59: macp.v1.ExperimentalCapabilities.FeaturesEntry
+	nil,                                  // 60: macp.v1.SessionStartPayload.ExtensionsEntry
+	nil,                                  // 61: macp.v1.TransportEndpoint.MetadataEntry
+	nil,                                  // 62: macp.v1.AgentManifest.MetadataEntry
+	nil,                                  // 63: macp.v1.ModeDescriptor.SchemaUrisEntry
+	(*PolicyRegistryCapability)(nil),     // 64: macp.v1.PolicyRegistryCapability
+	(SessionState)(0),                    // 65: macp.v1.SessionState
+	(*Envelope)(nil),                     // 66: macp.v1.Envelope
+	(*Ack)(nil),                          // 67: macp.v1.Ack
+	(*MACPError)(nil),                    // 68: macp.v1.MACPError
+	(*RegisterPolicyRequest)(nil),        // 69: macp.v1.RegisterPolicyRequest
+	(*UnregisterPolicyRequest)(nil),      // 70: macp.v1.UnregisterPolicyRequest
+	(*GetPolicyRequest)(nil),             // 71: macp.v1.GetPolicyRequest
+	(*ListPoliciesRequest)(nil),          // 72: macp.v1.ListPoliciesRequest
+	(*WatchPoliciesRequest)(nil),         // 73: macp.v1.WatchPoliciesRequest
+	(*RegisterPolicyResponse)(nil),       // 74: macp.v1.RegisterPolicyResponse
+	(*UnregisterPolicyResponse)(nil),     // 75: macp.v1.UnregisterPolicyResponse
+	(*GetPolicyResponse)(nil),            // 76: macp.v1.GetPolicyResponse
+	(*ListPoliciesResponse)(nil),         // 77: macp.v1.ListPoliciesResponse
+	(*WatchPoliciesResponse)(nil),        // 78: macp.v1.WatchPoliciesResponse
 }
 var file_macp_v1_core_proto_depIdxs = []int32{
-	53, // 0: macp.v1.ExperimentalCapabilities.features:type_name -> macp.v1.ExperimentalCapabilities.FeaturesEntry
-	3,  // 1: macp.v1.Capabilities.sessions:type_name -> macp.v1.SessionsCapability
-	4,  // 2: macp.v1.Capabilities.cancellation:type_name -> macp.v1.CancellationCapability
-	5,  // 3: macp.v1.Capabilities.progress:type_name -> macp.v1.ProgressCapability
-	6,  // 4: macp.v1.Capabilities.manifest:type_name -> macp.v1.ManifestCapability
-	7,  // 5: macp.v1.Capabilities.mode_registry:type_name -> macp.v1.ModeRegistryCapability
-	8,  // 6: macp.v1.Capabilities.roots:type_name -> macp.v1.RootsCapability
-	57, // 7: macp.v1.Capabilities.policy_registry:type_name -> macp.v1.PolicyRegistryCapability
-	9,  // 8: macp.v1.Capabilities.experimental:type_name -> macp.v1.ExperimentalCapabilities
-	1,  // 9: macp.v1.InitializeRequest.client_info:type_name -> macp.v1.ClientInfo
-	10, // 10: macp.v1.InitializeRequest.capabilities:type_name -> macp.v1.Capabilities
-	2,  // 11: macp.v1.InitializeResponse.runtime_info:type_name -> macp.v1.RuntimeInfo
-	10, // 12: macp.v1.InitializeResponse.capabilities:type_name -> macp.v1.Capabilities
-	0,  // 13: macp.v1.SessionStartPayload.roots:type_name -> macp.v1.Root
-	58, // 14: macp.v1.SessionMetadata.state:type_name -> macp.v1.SessionState
-	18, // 15: macp.v1.SessionMetadata.participant_activity:type_name -> macp.v1.ParticipantActivity
-	54, // 16: macp.v1.TransportEndpoint.metadata:type_name -> macp.v1.TransportEndpoint.MetadataEntry
-	55, // 17: macp.v1.AgentManifest.metadata:type_name -> macp.v1.AgentManifest.MetadataEntry
-	23, // 18: macp.v1.AgentManifest.transport_endpoints:type_name -> macp.v1.TransportEndpoint
-	56, // 19: macp.v1.ModeDescriptor.schema_uris:type_name -> macp.v1.ModeDescriptor.SchemaUrisEntry
-	25, // 20: macp.v1.ListModesResponse.modes:type_name -> macp.v1.ModeDescriptor
-	0,  // 21: macp.v1.ListRootsResponse.roots:type_name -> macp.v1.Root
-	59, // 22: macp.v1.SendRequest.envelope:type_name -> macp.v1.Envelope
-	60, // 23: macp.v1.SendResponse.ack:type_name -> macp.v1.Ack
-	59, // 24: macp.v1.StreamSessionRequest.envelope:type_name -> macp.v1.Envelope
-	59, // 25: macp.v1.StreamSessionResponse.envelope:type_name -> macp.v1.Envelope
-	19, // 26: macp.v1.GetSessionResponse.metadata:type_name -> macp.v1.SessionMetadata
-	60, // 27: macp.v1.CancelSessionResponse.ack:type_name -> macp.v1.Ack
-	24, // 28: macp.v1.GetManifestResponse.manifest:type_name -> macp.v1.AgentManifest
-	32, // 29: macp.v1.WatchModeRegistryResponse.change:type_name -> macp.v1.RegistryChanged
-	33, // 30: macp.v1.WatchRootsResponse.change:type_name -> macp.v1.RootsChanged
-	25, // 31: macp.v1.ListExtModesResponse.modes:type_name -> macp.v1.ModeDescriptor
-	25, // 32: macp.v1.RegisterExtModeRequest.mode_descriptor:type_name -> macp.v1.ModeDescriptor
-	59, // 33: macp.v1.WatchSignalsResponse.envelope:type_name -> macp.v1.Envelope
-	11, // 34: macp.v1.MACPRuntimeService.Initialize:input_type -> macp.v1.InitializeRequest
-	34, // 35: macp.v1.MACPRuntimeService.Send:input_type -> macp.v1.SendRequest
-	36, // 36: macp.v1.MACPRuntimeService.StreamSession:input_type -> macp.v1.StreamSessionRequest
-	20, // 37: macp.v1.MACPRuntimeService.GetSession:input_type -> macp.v1.GetSessionRequest
-	21, // 38: macp.v1.MACPRuntimeService.CancelSession:input_type -> macp.v1.CancelSessionRequest
-	22, // 39: macp.v1.MACPRuntimeService.GetManifest:input_type -> macp.v1.GetManifestRequest
-	26, // 40: macp.v1.MACPRuntimeService.ListModes:input_type -> macp.v1.ListModesRequest
-	30, // 41: macp.v1.MACPRuntimeService.WatchModeRegistry:input_type -> macp.v1.WatchModeRegistryRequest
-	28, // 42: macp.v1.MACPRuntimeService.ListRoots:input_type -> macp.v1.ListRootsRequest
-	31, // 43: macp.v1.MACPRuntimeService.WatchRoots:input_type -> macp.v1.WatchRootsRequest
-	43, // 44: macp.v1.MACPRuntimeService.ListExtModes:input_type -> macp.v1.ListExtModesRequest
-	45, // 45: macp.v1.MACPRuntimeService.RegisterExtMode:input_type -> macp.v1.RegisterExtModeRequest
-	47, // 46: macp.v1.MACPRuntimeService.UnregisterExtMode:input_type -> macp.v1.UnregisterExtModeRequest
-	49, // 47: macp.v1.MACPRuntimeService.PromoteMode:input_type -> macp.v1.PromoteModeRequest
-	51, // 48: macp.v1.MACPRuntimeService.WatchSignals:input_type -> macp.v1.WatchSignalsRequest
-	61, // 49: macp.v1.MACPRuntimeService.RegisterPolicy:input_type -> macp.v1.RegisterPolicyRequest
-	62, // 50: macp.v1.MACPRuntimeService.UnregisterPolicy:input_type -> macp.v1.UnregisterPolicyRequest
-	63, // 51: macp.v1.MACPRuntimeService.GetPolicy:input_type -> macp.v1.GetPolicyRequest
-	64, // 52: macp.v1.MACPRuntimeService.ListPolicies:input_type -> macp.v1.ListPoliciesRequest
-	65, // 53: macp.v1.MACPRuntimeService.WatchPolicies:input_type -> macp.v1.WatchPoliciesRequest
-	12, // 54: macp.v1.MACPRuntimeService.Initialize:output_type -> macp.v1.InitializeResponse
-	35, // 55: macp.v1.MACPRuntimeService.Send:output_type -> macp.v1.SendResponse
-	37, // 56: macp.v1.MACPRuntimeService.StreamSession:output_type -> macp.v1.StreamSessionResponse
-	38, // 57: macp.v1.MACPRuntimeService.GetSession:output_type -> macp.v1.GetSessionResponse
-	39, // 58: macp.v1.MACPRuntimeService.CancelSession:output_type -> macp.v1.CancelSessionResponse
-	40, // 59: macp.v1.MACPRuntimeService.GetManifest:output_type -> macp.v1.GetManifestResponse
-	27, // 60: macp.v1.MACPRuntimeService.ListModes:output_type -> macp.v1.ListModesResponse
-	41, // 61: macp.v1.MACPRuntimeService.WatchModeRegistry:output_type -> macp.v1.WatchModeRegistryResponse
-	29, // 62: macp.v1.MACPRuntimeService.ListRoots:output_type -> macp.v1.ListRootsResponse
-	42, // 63: macp.v1.MACPRuntimeService.WatchRoots:output_type -> macp.v1.WatchRootsResponse
-	44, // 64: macp.v1.MACPRuntimeService.ListExtModes:output_type -> macp.v1.ListExtModesResponse
-	46, // 65: macp.v1.MACPRuntimeService.RegisterExtMode:output_type -> macp.v1.RegisterExtModeResponse
-	48, // 66: macp.v1.MACPRuntimeService.UnregisterExtMode:output_type -> macp.v1.UnregisterExtModeResponse
-	50, // 67: macp.v1.MACPRuntimeService.PromoteMode:output_type -> macp.v1.PromoteModeResponse
-	52, // 68: macp.v1.MACPRuntimeService.WatchSignals:output_type -> macp.v1.WatchSignalsResponse
-	66, // 69: macp.v1.MACPRuntimeService.RegisterPolicy:output_type -> macp.v1.RegisterPolicyResponse
-	67, // 70: macp.v1.MACPRuntimeService.UnregisterPolicy:output_type -> macp.v1.UnregisterPolicyResponse
-	68, // 71: macp.v1.MACPRuntimeService.GetPolicy:output_type -> macp.v1.GetPolicyResponse
-	69, // 72: macp.v1.MACPRuntimeService.ListPolicies:output_type -> macp.v1.ListPoliciesResponse
-	70, // 73: macp.v1.MACPRuntimeService.WatchPolicies:output_type -> macp.v1.WatchPoliciesResponse
-	54, // [54:74] is the sub-list for method output_type
-	34, // [34:54] is the sub-list for method input_type
-	34, // [34:34] is the sub-list for extension type_name
-	34, // [34:34] is the sub-list for extension extendee
-	0,  // [0:34] is the sub-list for field type_name
+	59, // 0: macp.v1.ExperimentalCapabilities.features:type_name -> macp.v1.ExperimentalCapabilities.FeaturesEntry
+	4,  // 1: macp.v1.Capabilities.sessions:type_name -> macp.v1.SessionsCapability
+	5,  // 2: macp.v1.Capabilities.cancellation:type_name -> macp.v1.CancellationCapability
+	6,  // 3: macp.v1.Capabilities.progress:type_name -> macp.v1.ProgressCapability
+	7,  // 4: macp.v1.Capabilities.manifest:type_name -> macp.v1.ManifestCapability
+	8,  // 5: macp.v1.Capabilities.mode_registry:type_name -> macp.v1.ModeRegistryCapability
+	9,  // 6: macp.v1.Capabilities.roots:type_name -> macp.v1.RootsCapability
+	64, // 7: macp.v1.Capabilities.policy_registry:type_name -> macp.v1.PolicyRegistryCapability
+	10, // 8: macp.v1.Capabilities.experimental:type_name -> macp.v1.ExperimentalCapabilities
+	2,  // 9: macp.v1.InitializeRequest.client_info:type_name -> macp.v1.ClientInfo
+	11, // 10: macp.v1.InitializeRequest.capabilities:type_name -> macp.v1.Capabilities
+	3,  // 11: macp.v1.InitializeResponse.runtime_info:type_name -> macp.v1.RuntimeInfo
+	11, // 12: macp.v1.InitializeResponse.capabilities:type_name -> macp.v1.Capabilities
+	1,  // 13: macp.v1.SessionStartPayload.roots:type_name -> macp.v1.Root
+	60, // 14: macp.v1.SessionStartPayload.extensions:type_name -> macp.v1.SessionStartPayload.ExtensionsEntry
+	65, // 15: macp.v1.SessionMetadata.state:type_name -> macp.v1.SessionState
+	19, // 16: macp.v1.SessionMetadata.participant_activity:type_name -> macp.v1.ParticipantActivity
+	61, // 17: macp.v1.TransportEndpoint.metadata:type_name -> macp.v1.TransportEndpoint.MetadataEntry
+	62, // 18: macp.v1.AgentManifest.metadata:type_name -> macp.v1.AgentManifest.MetadataEntry
+	24, // 19: macp.v1.AgentManifest.transport_endpoints:type_name -> macp.v1.TransportEndpoint
+	63, // 20: macp.v1.ModeDescriptor.schema_uris:type_name -> macp.v1.ModeDescriptor.SchemaUrisEntry
+	26, // 21: macp.v1.ListModesResponse.modes:type_name -> macp.v1.ModeDescriptor
+	1,  // 22: macp.v1.ListRootsResponse.roots:type_name -> macp.v1.Root
+	66, // 23: macp.v1.SendRequest.envelope:type_name -> macp.v1.Envelope
+	67, // 24: macp.v1.SendResponse.ack:type_name -> macp.v1.Ack
+	66, // 25: macp.v1.StreamSessionRequest.envelope:type_name -> macp.v1.Envelope
+	66, // 26: macp.v1.StreamSessionResponse.envelope:type_name -> macp.v1.Envelope
+	68, // 27: macp.v1.StreamSessionResponse.error:type_name -> macp.v1.MACPError
+	20, // 28: macp.v1.GetSessionResponse.metadata:type_name -> macp.v1.SessionMetadata
+	67, // 29: macp.v1.CancelSessionResponse.ack:type_name -> macp.v1.Ack
+	25, // 30: macp.v1.GetManifestResponse.manifest:type_name -> macp.v1.AgentManifest
+	33, // 31: macp.v1.WatchModeRegistryResponse.change:type_name -> macp.v1.RegistryChanged
+	34, // 32: macp.v1.WatchRootsResponse.change:type_name -> macp.v1.RootsChanged
+	26, // 33: macp.v1.ListExtModesResponse.modes:type_name -> macp.v1.ModeDescriptor
+	26, // 34: macp.v1.RegisterExtModeRequest.mode_descriptor:type_name -> macp.v1.ModeDescriptor
+	66, // 35: macp.v1.WatchSignalsResponse.envelope:type_name -> macp.v1.Envelope
+	20, // 36: macp.v1.ListSessionsResponse.sessions:type_name -> macp.v1.SessionMetadata
+	0,  // 37: macp.v1.SessionLifecycleEvent.event_type:type_name -> macp.v1.SessionLifecycleEvent.EventType
+	20, // 38: macp.v1.SessionLifecycleEvent.session:type_name -> macp.v1.SessionMetadata
+	57, // 39: macp.v1.WatchSessionsResponse.event:type_name -> macp.v1.SessionLifecycleEvent
+	12, // 40: macp.v1.MACPRuntimeService.Initialize:input_type -> macp.v1.InitializeRequest
+	35, // 41: macp.v1.MACPRuntimeService.Send:input_type -> macp.v1.SendRequest
+	37, // 42: macp.v1.MACPRuntimeService.StreamSession:input_type -> macp.v1.StreamSessionRequest
+	21, // 43: macp.v1.MACPRuntimeService.GetSession:input_type -> macp.v1.GetSessionRequest
+	22, // 44: macp.v1.MACPRuntimeService.CancelSession:input_type -> macp.v1.CancelSessionRequest
+	23, // 45: macp.v1.MACPRuntimeService.GetManifest:input_type -> macp.v1.GetManifestRequest
+	27, // 46: macp.v1.MACPRuntimeService.ListModes:input_type -> macp.v1.ListModesRequest
+	31, // 47: macp.v1.MACPRuntimeService.WatchModeRegistry:input_type -> macp.v1.WatchModeRegistryRequest
+	29, // 48: macp.v1.MACPRuntimeService.ListRoots:input_type -> macp.v1.ListRootsRequest
+	32, // 49: macp.v1.MACPRuntimeService.WatchRoots:input_type -> macp.v1.WatchRootsRequest
+	44, // 50: macp.v1.MACPRuntimeService.ListExtModes:input_type -> macp.v1.ListExtModesRequest
+	46, // 51: macp.v1.MACPRuntimeService.RegisterExtMode:input_type -> macp.v1.RegisterExtModeRequest
+	48, // 52: macp.v1.MACPRuntimeService.UnregisterExtMode:input_type -> macp.v1.UnregisterExtModeRequest
+	50, // 53: macp.v1.MACPRuntimeService.PromoteMode:input_type -> macp.v1.PromoteModeRequest
+	52, // 54: macp.v1.MACPRuntimeService.WatchSignals:input_type -> macp.v1.WatchSignalsRequest
+	54, // 55: macp.v1.MACPRuntimeService.ListSessions:input_type -> macp.v1.ListSessionsRequest
+	56, // 56: macp.v1.MACPRuntimeService.WatchSessions:input_type -> macp.v1.WatchSessionsRequest
+	69, // 57: macp.v1.MACPRuntimeService.RegisterPolicy:input_type -> macp.v1.RegisterPolicyRequest
+	70, // 58: macp.v1.MACPRuntimeService.UnregisterPolicy:input_type -> macp.v1.UnregisterPolicyRequest
+	71, // 59: macp.v1.MACPRuntimeService.GetPolicy:input_type -> macp.v1.GetPolicyRequest
+	72, // 60: macp.v1.MACPRuntimeService.ListPolicies:input_type -> macp.v1.ListPoliciesRequest
+	73, // 61: macp.v1.MACPRuntimeService.WatchPolicies:input_type -> macp.v1.WatchPoliciesRequest
+	13, // 62: macp.v1.MACPRuntimeService.Initialize:output_type -> macp.v1.InitializeResponse
+	36, // 63: macp.v1.MACPRuntimeService.Send:output_type -> macp.v1.SendResponse
+	38, // 64: macp.v1.MACPRuntimeService.StreamSession:output_type -> macp.v1.StreamSessionResponse
+	39, // 65: macp.v1.MACPRuntimeService.GetSession:output_type -> macp.v1.GetSessionResponse
+	40, // 66: macp.v1.MACPRuntimeService.CancelSession:output_type -> macp.v1.CancelSessionResponse
+	41, // 67: macp.v1.MACPRuntimeService.GetManifest:output_type -> macp.v1.GetManifestResponse
+	28, // 68: macp.v1.MACPRuntimeService.ListModes:output_type -> macp.v1.ListModesResponse
+	42, // 69: macp.v1.MACPRuntimeService.WatchModeRegistry:output_type -> macp.v1.WatchModeRegistryResponse
+	30, // 70: macp.v1.MACPRuntimeService.ListRoots:output_type -> macp.v1.ListRootsResponse
+	43, // 71: macp.v1.MACPRuntimeService.WatchRoots:output_type -> macp.v1.WatchRootsResponse
+	45, // 72: macp.v1.MACPRuntimeService.ListExtModes:output_type -> macp.v1.ListExtModesResponse
+	47, // 73: macp.v1.MACPRuntimeService.RegisterExtMode:output_type -> macp.v1.RegisterExtModeResponse
+	49, // 74: macp.v1.MACPRuntimeService.UnregisterExtMode:output_type -> macp.v1.UnregisterExtModeResponse
+	51, // 75: macp.v1.MACPRuntimeService.PromoteMode:output_type -> macp.v1.PromoteModeResponse
+	53, // 76: macp.v1.MACPRuntimeService.WatchSignals:output_type -> macp.v1.WatchSignalsResponse
+	55, // 77: macp.v1.MACPRuntimeService.ListSessions:output_type -> macp.v1.ListSessionsResponse
+	58, // 78: macp.v1.MACPRuntimeService.WatchSessions:output_type -> macp.v1.WatchSessionsResponse
+	74, // 79: macp.v1.MACPRuntimeService.RegisterPolicy:output_type -> macp.v1.RegisterPolicyResponse
+	75, // 80: macp.v1.MACPRuntimeService.UnregisterPolicy:output_type -> macp.v1.UnregisterPolicyResponse
+	76, // 81: macp.v1.MACPRuntimeService.GetPolicy:output_type -> macp.v1.GetPolicyResponse
+	77, // 82: macp.v1.MACPRuntimeService.ListPolicies:output_type -> macp.v1.ListPoliciesResponse
+	78, // 83: macp.v1.MACPRuntimeService.WatchPolicies:output_type -> macp.v1.WatchPoliciesResponse
+	62, // [62:84] is the sub-list for method output_type
+	40, // [40:62] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_macp_v1_core_proto_init() }
@@ -3399,18 +3837,23 @@ func file_macp_v1_core_proto_init() {
 	}
 	file_macp_v1_envelope_proto_init()
 	file_macp_v1_policy_proto_init()
+	file_macp_v1_core_proto_msgTypes[37].OneofWrappers = []any{
+		(*StreamSessionResponse_Envelope)(nil),
+		(*StreamSessionResponse_Error)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_macp_v1_core_proto_rawDesc), len(file_macp_v1_core_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   57,
+			NumEnums:      1,
+			NumMessages:   63,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_macp_v1_core_proto_goTypes,
 		DependencyIndexes: file_macp_v1_core_proto_depIdxs,
+		EnumInfos:         file_macp_v1_core_proto_enumTypes,
 		MessageInfos:      file_macp_v1_core_proto_msgTypes,
 	}.Build()
 	File_macp_v1_core_proto = out.File

--- a/packages/proto-go/macp/v1/core_grpc.pb.go
+++ b/packages/proto-go/macp/v1/core_grpc.pb.go
@@ -34,6 +34,8 @@ const (
 	MACPRuntimeService_UnregisterExtMode_FullMethodName = "/macp.v1.MACPRuntimeService/UnregisterExtMode"
 	MACPRuntimeService_PromoteMode_FullMethodName       = "/macp.v1.MACPRuntimeService/PromoteMode"
 	MACPRuntimeService_WatchSignals_FullMethodName      = "/macp.v1.MACPRuntimeService/WatchSignals"
+	MACPRuntimeService_ListSessions_FullMethodName      = "/macp.v1.MACPRuntimeService/ListSessions"
+	MACPRuntimeService_WatchSessions_FullMethodName     = "/macp.v1.MACPRuntimeService/WatchSessions"
 	MACPRuntimeService_RegisterPolicy_FullMethodName    = "/macp.v1.MACPRuntimeService/RegisterPolicy"
 	MACPRuntimeService_UnregisterPolicy_FullMethodName  = "/macp.v1.MACPRuntimeService/UnregisterPolicy"
 	MACPRuntimeService_GetPolicy_FullMethodName         = "/macp.v1.MACPRuntimeService/GetPolicy"
@@ -62,6 +64,9 @@ type MACPRuntimeServiceClient interface {
 	PromoteMode(ctx context.Context, in *PromoteModeRequest, opts ...grpc.CallOption) (*PromoteModeResponse, error)
 	// Ambient Signal observation
 	WatchSignals(ctx context.Context, in *WatchSignalsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchSignalsResponse], error)
+	// Session lifecycle observation (RFC-MACP-0001 §7.3)
+	ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error)
+	WatchSessions(ctx context.Context, in *WatchSessionsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchSessionsResponse], error)
 	// Governance policy lifecycle (RFC-MACP-0012)
 	RegisterPolicy(ctx context.Context, in *RegisterPolicyRequest, opts ...grpc.CallOption) (*RegisterPolicyResponse, error)
 	UnregisterPolicy(ctx context.Context, in *UnregisterPolicyRequest, opts ...grpc.CallOption) (*UnregisterPolicyResponse, error)
@@ -258,6 +263,35 @@ func (c *mACPRuntimeServiceClient) WatchSignals(ctx context.Context, in *WatchSi
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type MACPRuntimeService_WatchSignalsClient = grpc.ServerStreamingClient[WatchSignalsResponse]
 
+func (c *mACPRuntimeServiceClient) ListSessions(ctx context.Context, in *ListSessionsRequest, opts ...grpc.CallOption) (*ListSessionsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSessionsResponse)
+	err := c.cc.Invoke(ctx, MACPRuntimeService_ListSessions_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *mACPRuntimeServiceClient) WatchSessions(ctx context.Context, in *WatchSessionsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchSessionsResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &MACPRuntimeService_ServiceDesc.Streams[4], MACPRuntimeService_WatchSessions_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[WatchSessionsRequest, WatchSessionsResponse]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type MACPRuntimeService_WatchSessionsClient = grpc.ServerStreamingClient[WatchSessionsResponse]
+
 func (c *mACPRuntimeServiceClient) RegisterPolicy(ctx context.Context, in *RegisterPolicyRequest, opts ...grpc.CallOption) (*RegisterPolicyResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RegisterPolicyResponse)
@@ -300,7 +334,7 @@ func (c *mACPRuntimeServiceClient) ListPolicies(ctx context.Context, in *ListPol
 
 func (c *mACPRuntimeServiceClient) WatchPolicies(ctx context.Context, in *WatchPoliciesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[WatchPoliciesResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &MACPRuntimeService_ServiceDesc.Streams[4], MACPRuntimeService_WatchPolicies_FullMethodName, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &MACPRuntimeService_ServiceDesc.Streams[5], MACPRuntimeService_WatchPolicies_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -338,6 +372,9 @@ type MACPRuntimeServiceServer interface {
 	PromoteMode(context.Context, *PromoteModeRequest) (*PromoteModeResponse, error)
 	// Ambient Signal observation
 	WatchSignals(*WatchSignalsRequest, grpc.ServerStreamingServer[WatchSignalsResponse]) error
+	// Session lifecycle observation (RFC-MACP-0001 §7.3)
+	ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error)
+	WatchSessions(*WatchSessionsRequest, grpc.ServerStreamingServer[WatchSessionsResponse]) error
 	// Governance policy lifecycle (RFC-MACP-0012)
 	RegisterPolicy(context.Context, *RegisterPolicyRequest) (*RegisterPolicyResponse, error)
 	UnregisterPolicy(context.Context, *UnregisterPolicyRequest) (*UnregisterPolicyResponse, error)
@@ -398,6 +435,12 @@ func (UnimplementedMACPRuntimeServiceServer) PromoteMode(context.Context, *Promo
 }
 func (UnimplementedMACPRuntimeServiceServer) WatchSignals(*WatchSignalsRequest, grpc.ServerStreamingServer[WatchSignalsResponse]) error {
 	return status.Error(codes.Unimplemented, "method WatchSignals not implemented")
+}
+func (UnimplementedMACPRuntimeServiceServer) ListSessions(context.Context, *ListSessionsRequest) (*ListSessionsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSessions not implemented")
+}
+func (UnimplementedMACPRuntimeServiceServer) WatchSessions(*WatchSessionsRequest, grpc.ServerStreamingServer[WatchSessionsResponse]) error {
+	return status.Error(codes.Unimplemented, "method WatchSessions not implemented")
 }
 func (UnimplementedMACPRuntimeServiceServer) RegisterPolicy(context.Context, *RegisterPolicyRequest) (*RegisterPolicyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RegisterPolicy not implemented")
@@ -673,6 +716,35 @@ func _MACPRuntimeService_WatchSignals_Handler(srv interface{}, stream grpc.Serve
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type MACPRuntimeService_WatchSignalsServer = grpc.ServerStreamingServer[WatchSignalsResponse]
 
+func _MACPRuntimeService_ListSessions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSessionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(MACPRuntimeServiceServer).ListSessions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: MACPRuntimeService_ListSessions_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(MACPRuntimeServiceServer).ListSessions(ctx, req.(*ListSessionsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _MACPRuntimeService_WatchSessions_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(WatchSessionsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(MACPRuntimeServiceServer).WatchSessions(m, &grpc.GenericServerStream[WatchSessionsRequest, WatchSessionsResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type MACPRuntimeService_WatchSessionsServer = grpc.ServerStreamingServer[WatchSessionsResponse]
+
 func _MACPRuntimeService_RegisterPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(RegisterPolicyRequest)
 	if err := dec(in); err != nil {
@@ -808,6 +880,10 @@ var MACPRuntimeService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _MACPRuntimeService_PromoteMode_Handler,
 		},
 		{
+			MethodName: "ListSessions",
+			Handler:    _MACPRuntimeService_ListSessions_Handler,
+		},
+		{
 			MethodName: "RegisterPolicy",
 			Handler:    _MACPRuntimeService_RegisterPolicy_Handler,
 		},
@@ -844,6 +920,11 @@ var MACPRuntimeService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "WatchSignals",
 			Handler:       _MACPRuntimeService_WatchSignals_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "WatchSessions",
+			Handler:       _MACPRuntimeService_WatchSessions_Handler,
 			ServerStreams: true,
 		},
 		{

--- a/packages/proto-go/macp/v1/policy.pb.go
+++ b/packages/proto-go/macp/v1/policy.pb.go
@@ -34,14 +34,12 @@ type PolicyDescriptor struct {
 	// JSON-encoded governance rules per the target mode's rule schema.
 	// The structure of this JSON is defined by the mode-specific rule JSON Schema
 	// (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
-	Rules []byte `protobuf:"bytes,4,opt,name=rules,proto3" json:"rules,omitempty"`
+	Rules string `protobuf:"bytes,4,opt,name=rules,proto3" json:"rules,omitempty"`
 	// Version of the rule schema used (currently 1).
-	SchemaVersion uint32 `protobuf:"varint,5,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"`
-	// ISO 8601 timestamp of when this policy was registered.
-	// Set by the runtime; ignored in RegisterPolicyRequest.
-	RegisteredAt  string `protobuf:"bytes,6,opt,name=registered_at,json=registeredAt,proto3" json:"registered_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	SchemaVersion      uint32 `protobuf:"varint,5,opt,name=schema_version,json=schemaVersion,proto3" json:"schema_version,omitempty"`
+	RegisteredAtUnixMs int64  `protobuf:"varint,6,opt,name=registered_at_unix_ms,json=registeredAtUnixMs,proto3" json:"registered_at_unix_ms,omitempty"` // Unix epoch milliseconds; set by the runtime, ignored in RegisterPolicyRequest.
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *PolicyDescriptor) Reset() {
@@ -95,11 +93,11 @@ func (x *PolicyDescriptor) GetDescription() string {
 	return ""
 }
 
-func (x *PolicyDescriptor) GetRules() []byte {
+func (x *PolicyDescriptor) GetRules() string {
 	if x != nil {
 		return x.Rules
 	}
-	return nil
+	return ""
 }
 
 func (x *PolicyDescriptor) GetSchemaVersion() uint32 {
@@ -109,11 +107,11 @@ func (x *PolicyDescriptor) GetSchemaVersion() uint32 {
 	return 0
 }
 
-func (x *PolicyDescriptor) GetRegisteredAt() string {
+func (x *PolicyDescriptor) GetRegisteredAtUnixMs() int64 {
 	if x != nil {
-		return x.RegisteredAt
+		return x.RegisteredAtUnixMs
 	}
-	return ""
+	return 0
 }
 
 // Policy registry capability advertised during Initialize.
@@ -586,7 +584,7 @@ func (*WatchPoliciesRequest) Descriptor() ([]byte, []int) {
 type WatchPoliciesResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Descriptors      []*PolicyDescriptor    `protobuf:"bytes,1,rep,name=descriptors,proto3" json:"descriptors,omitempty"`
-	ObservedAtUnixMs uint64                 `protobuf:"varint,2,opt,name=observed_at_unix_ms,json=observedAtUnixMs,proto3" json:"observed_at_unix_ms,omitempty"`
+	ObservedAtUnixMs int64                  `protobuf:"varint,2,opt,name=observed_at_unix_ms,json=observedAtUnixMs,proto3" json:"observed_at_unix_ms,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -628,7 +626,7 @@ func (x *WatchPoliciesResponse) GetDescriptors() []*PolicyDescriptor {
 	return nil
 }
 
-func (x *WatchPoliciesResponse) GetObservedAtUnixMs() uint64 {
+func (x *WatchPoliciesResponse) GetObservedAtUnixMs() int64 {
 	if x != nil {
 		return x.ObservedAtUnixMs
 	}
@@ -639,14 +637,14 @@ var File_macp_v1_policy_proto protoreflect.FileDescriptor
 
 const file_macp_v1_policy_proto_rawDesc = "" +
 	"\n" +
-	"\x14macp/v1/policy.proto\x12\amacp.v1\"\xc7\x01\n" +
+	"\x14macp/v1/policy.proto\x12\amacp.v1\"\xd5\x01\n" +
 	"\x10PolicyDescriptor\x12\x1b\n" +
 	"\tpolicy_id\x18\x01 \x01(\tR\bpolicyId\x12\x12\n" +
 	"\x04mode\x18\x02 \x01(\tR\x04mode\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x14\n" +
-	"\x05rules\x18\x04 \x01(\fR\x05rules\x12%\n" +
-	"\x0eschema_version\x18\x05 \x01(\rR\rschemaVersion\x12#\n" +
-	"\rregistered_at\x18\x06 \x01(\tR\fregisteredAt\"\x8b\x01\n" +
+	"\x05rules\x18\x04 \x01(\tR\x05rules\x12%\n" +
+	"\x0eschema_version\x18\x05 \x01(\rR\rschemaVersion\x121\n" +
+	"\x15registered_at_unix_ms\x18\x06 \x01(\x03R\x12registeredAtUnixMs\"\x8b\x01\n" +
 	"\x18PolicyRegistryCapability\x12'\n" +
 	"\x0fregister_policy\x18\x01 \x01(\bR\x0eregisterPolicy\x12#\n" +
 	"\rlist_policies\x18\x02 \x01(\bR\flistPolicies\x12!\n" +
@@ -672,7 +670,7 @@ const file_macp_v1_policy_proto_rawDesc = "" +
 	"\x14WatchPoliciesRequest\"\x83\x01\n" +
 	"\x15WatchPoliciesResponse\x12;\n" +
 	"\vdescriptors\x18\x01 \x03(\v2\x19.macp.v1.PolicyDescriptorR\vdescriptors\x12-\n" +
-	"\x13observed_at_unix_ms\x18\x02 \x01(\x04R\x10observedAtUnixMsB\x9f\x01\n" +
+	"\x13observed_at_unix_ms\x18\x02 \x01(\x03R\x10observedAtUnixMsB\x9f\x01\n" +
 	"\vcom.macp.v1B\vPolicyProtoP\x01ZFgithub.com/multiagentcoordinationprotocol/macp-proto-go/macp/v1;macpv1\xa2\x02\x03MXX\xaa\x02\aMacp.V1\xca\x02\aMacp\\V1\xe2\x02\x13Macp\\V1\\GPBMetadata\xea\x02\bMacp::V1b\x06proto3"
 
 var (

--- a/packages/proto-npm/proto/macp/v1/core.proto
+++ b/packages/proto-npm/proto/macp/v1/core.proto
@@ -253,6 +253,16 @@ message SendResponse {
 // Standard per-message negative acknowledgements remain the responsibility of Send.
 message StreamSessionRequest {
   Envelope envelope = 1;
+
+  // Passive session subscription (RFC-MACP-0006 §3.2). When set without an
+  // envelope, binds the stream to the session's broadcast: the runtime first
+  // replays accepted session history from after_sequence onwards, then
+  // switches seamlessly to live broadcast. The caller MUST be an
+  // authenticated declared participant of the session or an observer
+  // identity admitted by deployment policy (RFC-MACP-0004 §4). A single
+  // request MUST NOT set both envelope and subscribe_session_id.
+  string subscribe_session_id = 2;
+  uint64 after_sequence = 3;  // 0 = replay from session start
 }
 
 message StreamSessionResponse {

--- a/packages/proto-python/src/macp/v1/core_pb2_grpc.py
+++ b/packages/proto-python/src/macp/v1/core_pb2_grpc.py
@@ -110,6 +110,16 @@ class MACPRuntimeServiceStub(object):
                 request_serializer=macp_dot_v1_dot_core__pb2.WatchSignalsRequest.SerializeToString,
                 response_deserializer=macp_dot_v1_dot_core__pb2.WatchSignalsResponse.FromString,
                 _registered_method=True)
+        self.ListSessions = channel.unary_unary(
+                '/macp.v1.MACPRuntimeService/ListSessions',
+                request_serializer=macp_dot_v1_dot_core__pb2.ListSessionsRequest.SerializeToString,
+                response_deserializer=macp_dot_v1_dot_core__pb2.ListSessionsResponse.FromString,
+                _registered_method=True)
+        self.WatchSessions = channel.unary_stream(
+                '/macp.v1.MACPRuntimeService/WatchSessions',
+                request_serializer=macp_dot_v1_dot_core__pb2.WatchSessionsRequest.SerializeToString,
+                response_deserializer=macp_dot_v1_dot_core__pb2.WatchSessionsResponse.FromString,
+                _registered_method=True)
         self.RegisterPolicy = channel.unary_unary(
                 '/macp.v1.MACPRuntimeService/RegisterPolicy',
                 request_serializer=macp_dot_v1_dot_policy__pb2.RegisterPolicyRequest.SerializeToString,
@@ -232,6 +242,19 @@ class MACPRuntimeServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ListSessions(self, request, context):
+        """Session lifecycle observation (RFC-MACP-0001 §7.3)
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def WatchSessions(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def RegisterPolicy(self, request, context):
         """Governance policy lifecycle (RFC-MACP-0012)
         """
@@ -340,6 +363,16 @@ def add_MACPRuntimeServiceServicer_to_server(servicer, server):
                     servicer.WatchSignals,
                     request_deserializer=macp_dot_v1_dot_core__pb2.WatchSignalsRequest.FromString,
                     response_serializer=macp_dot_v1_dot_core__pb2.WatchSignalsResponse.SerializeToString,
+            ),
+            'ListSessions': grpc.unary_unary_rpc_method_handler(
+                    servicer.ListSessions,
+                    request_deserializer=macp_dot_v1_dot_core__pb2.ListSessionsRequest.FromString,
+                    response_serializer=macp_dot_v1_dot_core__pb2.ListSessionsResponse.SerializeToString,
+            ),
+            'WatchSessions': grpc.unary_stream_rpc_method_handler(
+                    servicer.WatchSessions,
+                    request_deserializer=macp_dot_v1_dot_core__pb2.WatchSessionsRequest.FromString,
+                    response_serializer=macp_dot_v1_dot_core__pb2.WatchSessionsResponse.SerializeToString,
             ),
             'RegisterPolicy': grpc.unary_unary_rpc_method_handler(
                     servicer.RegisterPolicy,
@@ -772,6 +805,60 @@ class MACPRuntimeService(object):
             '/macp.v1.MACPRuntimeService/WatchSignals',
             macp_dot_v1_dot_core__pb2.WatchSignalsRequest.SerializeToString,
             macp_dot_v1_dot_core__pb2.WatchSignalsResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def ListSessions(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/macp.v1.MACPRuntimeService/ListSessions',
+            macp_dot_v1_dot_core__pb2.ListSessionsRequest.SerializeToString,
+            macp_dot_v1_dot_core__pb2.ListSessionsResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def WatchSessions(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(
+            request,
+            target,
+            '/macp.v1.MACPRuntimeService/WatchSessions',
+            macp_dot_v1_dot_core__pb2.WatchSessionsRequest.SerializeToString,
+            macp_dot_v1_dot_core__pb2.WatchSessionsResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/packages/proto-rust/proto/macp/v1/core.proto
+++ b/packages/proto-rust/proto/macp/v1/core.proto
@@ -253,6 +253,16 @@ message SendResponse {
 // Standard per-message negative acknowledgements remain the responsibility of Send.
 message StreamSessionRequest {
   Envelope envelope = 1;
+
+  // Passive session subscription (RFC-MACP-0006 §3.2). When set without an
+  // envelope, binds the stream to the session's broadcast: the runtime first
+  // replays accepted session history from after_sequence onwards, then
+  // switches seamlessly to live broadcast. The caller MUST be an
+  // authenticated declared participant of the session or an observer
+  // identity admitted by deployment policy (RFC-MACP-0004 §4). A single
+  // request MUST NOT set both envelope and subscribe_session_id.
+  string subscribe_session_id = 2;
+  uint64 after_sequence = 3;  // 0 = replay from session start
 }
 
 message StreamSessionResponse {

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -2,9 +2,11 @@
 # Multi-Agent Coordination Protocol (MACP) — Transport Bindings
 
 **Document:** RFC-MACP-0006
-**Version:** 1.0.0-draft
+**Version:** 1.1.0-draft
 **Status:** Community Standards Track
 **Updates:** RFC-MACP-0001
+
+> **Changelog — 1.1.0-draft:** passive session subscription is promoted from the former Appendix A.1 to core `StreamSession` semantics in §3.2. `subscribe_session_id` and `after_sequence` are normative on every runtime that advertises `sessions.stream = true`; they are not an optional capability.
 
 ## 1. Introduction
 
@@ -85,7 +87,25 @@ A runtime that advertises `sessions.stream = true` MUST implement `StreamSession
 
 A runtime MAY echo back accepted client-submitted envelopes on the stream as part of the authoritative accepted sequence.
 
-The base protocol does **not** define a passive attach or no-op envelope for observing an existing session without sending a new session-scoped coordination message. Session-scoped `Signal` envelopes are invalid in the base protocol and MUST NOT be used as a stream-attach mechanism. Clients that need zero-mutation observation SHOULD either begin streaming before the session activity of interest or rely on a deployment-specific extension outside the base protocol.
+Session-scoped `Signal` envelopes are invalid in the base protocol and MUST NOT be used as a stream-attach mechanism. Clients that need zero-mutation observation of an existing session MUST use the passive session subscription semantics defined below.
+
+#### Passive Session Subscription
+
+`StreamSessionRequest` carries two session-binding shapes:
+
+- `envelope` — a session-scoped coordination envelope. Standard `StreamSession` behavior as specified above.
+- `subscribe_session_id` (with optional `after_sequence`) — a passive-subscribe frame that binds the stream to an existing session's broadcast without emitting a coordination message.
+
+A single `StreamSessionRequest` MUST NOT set both `envelope` and `subscribe_session_id`; a runtime MUST reject such a request as an invalid argument.
+
+On a request with `subscribe_session_id` set, a runtime that advertises `sessions.stream = true` MUST:
+
+1. Authorize the caller. The caller MUST be an authenticated declared participant of the session, or an observer identity admitted by deployment policy (RFC-MACP-0004 §4). Unauthorized callers MUST be rejected.
+2. Replay accepted session envelopes in strict acceptance order starting from `after_sequence + 1`. When `after_sequence = 0`, replay begins at the session's first accepted envelope.
+3. Switch seamlessly to live broadcast on the same stream after replay drains, preserving within-session acceptance order.
+4. Never replay rejected envelopes (RFC-MACP-0001 §7.2); only accepted-history envelopes are delivered.
+
+A stream opened with a passive-subscribe frame is conventionally read-only. Implementations MAY refuse subsequent envelope frames on such a stream; clients that intend to coordinate on the session SHOULD open a separate `StreamSession` or use unary `Send`.
 
 When a transport-level or stream-fatal error occurs, the runtime SHOULD use native gRPC stream termination semantics.
 

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -253,6 +253,16 @@ message SendResponse {
 // Standard per-message negative acknowledgements remain the responsibility of Send.
 message StreamSessionRequest {
   Envelope envelope = 1;
+
+  // Passive session subscription (RFC-MACP-0006 §3.2). When set without an
+  // envelope, binds the stream to the session's broadcast: the runtime first
+  // replays accepted session history from after_sequence onwards, then
+  // switches seamlessly to live broadcast. The caller MUST be an
+  // authenticated declared participant of the session or an observer
+  // identity admitted by deployment policy (RFC-MACP-0004 §4). A single
+  // request MUST NOT set both envelope and subscribe_session_id.
+  string subscribe_session_id = 2;
+  uint64 after_sequence = 3;  // 0 = replay from session start
 }
 
 message StreamSessionResponse {

--- a/scripts/check-go-stubs.sh
+++ b/scripts/check-go-stubs.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Check that the committed Go protobuf stubs in packages/proto-go/ match
+# what buf generate produces from the canonical schemas/proto tree.
+#
+# The matching is content-based: the protoc-gen-go tool version line is
+# normalized away before comparison so that differences in the local
+# generator version don't trigger spurious failures.
+#
+# Exits 0 on match, 1 on drift (prints unified diffs for each offender).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GO_PKG_DIR="${PROJECT_ROOT}/packages/proto-go/macp"
+
+if ! command -v buf >/dev/null 2>&1; then
+    echo "Skipping: buf not installed."
+    exit 0
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+    echo "Skipping: go not installed."
+    exit 0
+fi
+
+PLUGIN_BIN="$(mktemp -d)"
+TMP_OUT="$(mktemp -d)"
+trap 'rm -rf "${PLUGIN_BIN}" "${TMP_OUT}"' EXIT
+
+echo "Installing Go protoc plugins into ${PLUGIN_BIN} ..."
+GOBIN="${PLUGIN_BIN}" go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+GOBIN="${PLUGIN_BIN}" go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+# Use a template that points to the locally-installed plugins (no BSR auth
+# required) but replicates the same managed-mode settings as the canonical
+# buf/buf.gen.go.yaml. The template must live inside a stable directory so
+# that buf's relative-path resolution is predictable.
+TEMPLATE_FILE="${PROJECT_ROOT}/buf/buf.gen.go.local.generated.yaml"
+cat > "${TEMPLATE_FILE}" <<EOF
+version: v2
+managed:
+  enabled: true
+  override:
+    - file_option: go_package_prefix
+      value: github.com/multiagentcoordinationprotocol/macp-proto-go
+plugins:
+  - local: protoc-gen-go
+    out: ${TMP_OUT}
+    opt:
+      - paths=source_relative
+  - local: protoc-gen-go-grpc
+    out: ${TMP_OUT}
+    opt:
+      - paths=source_relative
+EOF
+trap 'rm -rf "${PLUGIN_BIN}" "${TMP_OUT}"; rm -f "${TEMPLATE_FILE}"' EXIT
+
+echo "Regenerating Go stubs into ${TMP_OUT} ..."
+(
+    cd "${PROJECT_ROOT}"
+    PATH="${PLUGIN_BIN}:${PATH}" buf generate \
+        --template "${TEMPLATE_FILE}"
+)
+
+ERRORS=0
+
+# Normalize tool version strings so differences in the local plugin
+# version don't trigger spurious drift.
+normalize() {
+    sed -E \
+        -e 's|^// - protoc-gen-go[^ ]*[[:space:]]+v[0-9.]+.*$|// - protoc-gen-go NORMALIZED|' \
+        -e 's|^// - protoc-gen-go-grpc[^ ]*[[:space:]]+v[0-9.]+.*$|// - protoc-gen-go-grpc NORMALIZED|' \
+        -e 's|^// - protoc[[:space:]]+.*$|// - protoc NORMALIZED|' \
+        -e 's|^//[[:space:]]+protoc-gen-go[[:space:]]+v[0-9.]+.*$|// protoc-gen-go NORMALIZED|'
+}
+
+echo ""
+echo "Comparing committed stubs against freshly-generated output ..."
+while IFS= read -r -d '' committed; do
+    rel="${committed#${GO_PKG_DIR}/}"
+    generated="${TMP_OUT}/macp/${rel}"
+
+    if [[ ! -f "${generated}" ]]; then
+        echo "MISSING (generated): macp/${rel}"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+
+    if ! diff -q \
+        <(normalize < "${committed}") \
+        <(normalize < "${generated}") >/dev/null 2>&1; then
+        echo ""
+        echo "DRIFT: packages/proto-go/macp/${rel}"
+        diff --unified=3 \
+            <(normalize < "${committed}") \
+            <(normalize < "${generated}") | head -60 || true
+        ERRORS=$((ERRORS + 1))
+    fi
+done < <(find "${GO_PKG_DIR}" -type f -name '*.go' -print0)
+
+echo ""
+if [[ ${ERRORS} -gt 0 ]]; then
+    echo "✗ ${ERRORS} Go stub(s) are out of sync with canonical protos."
+    echo "  Regenerate with:"
+    echo "    buf generate --template buf/buf.gen.go.yaml"
+    exit 1
+fi
+
+echo "✓ All committed Go protobuf stubs are in sync with canonical protos."

--- a/scripts/check-python-stubs.sh
+++ b/scripts/check-python-stubs.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+# Check that the committed Python _pb2_grpc.py stubs in packages/proto-python/
+# match what grpc_tools.protoc produces from the canonical schemas/proto tree.
+#
+# The matching is content-based: the auto-generated GRPC_GENERATED_VERSION line
+# is normalized away before comparison so that differences in the local
+# grpcio-tools version don't trigger spurious failures.
+#
+# Exits 0 on match, 1 on drift (prints unified diffs for each offender).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROTO_DIR="${PROJECT_ROOT}/schemas/proto"
+PY_DIR="${PROJECT_ROOT}/packages/proto-python/src"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Skipping: python3 not available."
+    exit 0
+fi
+
+if ! python3 -c "import grpc_tools" >/dev/null 2>&1; then
+    echo "Skipping: grpcio-tools not installed. Install with:"
+    echo "  pip install grpcio-tools"
+    exit 0
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+echo "Generating Python protobuf stubs into ${TMP_DIR} ..."
+python3 -m grpc_tools.protoc \
+    -I"${PROTO_DIR}" \
+    --python_out="${TMP_DIR}" \
+    --grpc_python_out="${TMP_DIR}" \
+    macp/v1/envelope.proto \
+    macp/v1/core.proto \
+    macp/v1/policy.proto \
+    macp/modes/decision/v1/decision.proto \
+    macp/modes/proposal/v1/proposal.proto \
+    macp/modes/task/v1/task.proto \
+    macp/modes/handoff/v1/handoff.proto \
+    macp/modes/quorum/v1/quorum.proto
+
+ERRORS=0
+
+# List of committed _pb2_grpc.py files (relative to packages/proto-python/src).
+STUBS=(
+    "macp/v1/envelope_pb2_grpc.py"
+    "macp/v1/core_pb2_grpc.py"
+    "macp/v1/policy_pb2_grpc.py"
+    "macp/modes/decision/v1/decision_pb2_grpc.py"
+    "macp/modes/proposal/v1/proposal_pb2_grpc.py"
+    "macp/modes/task/v1/task_pb2_grpc.py"
+    "macp/modes/handoff/v1/handoff_pb2_grpc.py"
+    "macp/modes/quorum/v1/quorum_pb2_grpc.py"
+)
+
+# Normalize away the auto-tool version string so differences in the local
+# grpcio-tools version don't trigger spurious drift.
+normalize() {
+    sed -E "s/^GRPC_GENERATED_VERSION = '[^']*'/GRPC_GENERATED_VERSION = 'NORMALIZED'/"
+}
+
+echo ""
+echo "Comparing committed stubs against freshly-generated output ..."
+for rel in "${STUBS[@]}"; do
+    committed="${PY_DIR}/${rel}"
+    generated="${TMP_DIR}/${rel}"
+
+    if [[ ! -f "${committed}" ]]; then
+        echo "MISSING (committed): ${rel}"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+
+    if [[ ! -f "${generated}" ]]; then
+        echo "MISSING (generated): ${rel}"
+        ERRORS=$((ERRORS + 1))
+        continue
+    fi
+
+    if ! diff -q \
+        <(normalize < "${committed}") \
+        <(normalize < "${generated}") >/dev/null 2>&1; then
+        echo ""
+        echo "DRIFT: ${rel}"
+        diff --unified=3 \
+            <(normalize < "${committed}") \
+            <(normalize < "${generated}") | head -60 || true
+        ERRORS=$((ERRORS + 1))
+    fi
+done
+
+echo ""
+if [[ ${ERRORS} -gt 0 ]]; then
+    echo "✗ ${ERRORS} Python stub(s) are out of sync with canonical protos."
+    echo "  Regenerate with:"
+    echo "    python -m grpc_tools.protoc \\"
+    echo "      -Ischemas/proto \\"
+    echo "      --python_out=packages/proto-python/src \\"
+    echo "      --grpc_python_out=packages/proto-python/src \\"
+    echo "      macp/v1/*.proto macp/modes/*/v1/*.proto"
+    exit 1
+fi
+
+echo "✓ All committed Python _pb2_grpc.py stubs are in sync with canonical protos."

--- a/scripts/sync-proto-packages.sh
+++ b/scripts/sync-proto-packages.sh
@@ -2,9 +2,9 @@
 
 # Sync canonical proto files from schemas/proto/ to raw-proto packages.
 #
-# Packages that ship raw .proto files (proto-npm, proto-rust, proto-swift)
-# must stay byte-for-byte identical to the canonical schemas.  This script
-# copies the canonical protos into each package directory.
+# Packages that ship raw .proto files (proto-npm, proto-rust) must stay
+# byte-for-byte identical to the canonical schemas.  This script copies
+# the canonical protos into each package directory.
 #
 # Usage:
 #   ./scripts/sync-proto-packages.sh          # copy canonical → packages
@@ -20,7 +20,6 @@ CANONICAL="${PROJECT_ROOT}/schemas/proto"
 RAW_PACKAGES=(
   "packages/proto-npm/proto"
   "packages/proto-rust/proto"
-  "packages/proto-swift/proto"
 )
 
 CHECK_MODE=false

--- a/scripts/validate-json.sh
+++ b/scripts/validate-json.sh
@@ -11,6 +11,10 @@ ENVELOPE_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-envelope.schema.json"
 MANIFEST_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-agent-manifest.schema.json"
 DESCRIPTOR_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-mode-descriptor.schema.json"
 POLICY_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-policy-descriptor.schema.json"
+SESSION_METADATA_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-session-metadata.schema.json"
+SESSION_LIFECYCLE_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-session-lifecycle-event.schema.json"
+RUN_DESCRIPTOR_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-run-descriptor.schema.json"
+AGENT_BOOTSTRAP_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-agent-bootstrap.schema.json"
 EXAMPLES_DIR="${PROJECT_ROOT}/examples/json"
 DISCOVERY_DIR="${PROJECT_ROOT}/examples/discovery"
 TRANSCRIPT_GLOB="${PROJECT_ROOT}/examples/*.json"
@@ -103,15 +107,50 @@ if [ -d "$DISCOVERY_DIR" ]; then
             echo ""
         fi
     done
+
+    # Validate any discovery file whose name prefix matches a schema.
+    # Each pair is "<filename-glob>:<schema-path>:<label>".
+    EXTRA_DISCOVERY_PAIRS=(
+        "session_metadata:${SESSION_METADATA_SCHEMA}:session-metadata"
+        "session_lifecycle_event:${SESSION_LIFECYCLE_SCHEMA}:session-lifecycle-event"
+        "run_descriptor:${RUN_DESCRIPTOR_SCHEMA}:run-descriptor"
+        "agent_bootstrap:${AGENT_BOOTSTRAP_SCHEMA}:agent-bootstrap"
+    )
+    for pair in "${EXTRA_DISCOVERY_PAIRS[@]}"; do
+        prefix="${pair%%:*}"
+        rest="${pair#*:}"
+        schema="${rest%%:*}"
+        label="${rest##*:}"
+        for example_file in "${DISCOVERY_DIR}/${prefix}"*.json; do
+            if [ -f "$example_file" ]; then
+                TOTAL=$((TOTAL + 1))
+                echo "Validating: discovery/$(basename "$example_file") against ${label} schema"
+
+                if ajv validate -s "${schema}" -d "${example_file}" --spec=draft2020 --strict=false; then
+                    VALIDATED=$((VALIDATED + 1))
+                    echo "  [OK] Valid"
+                else
+                    echo "  [X] Invalid"
+                    exit 1
+                fi
+                echo ""
+            fi
+        done
+    done
 fi
 
-echo "-- Composite transcripts and policy examples (syntax check only) --"
+echo "-- Composite transcripts and policy examples --"
+echo "  Syntax check, and (for transcripts with a 'messages' array) per-envelope validation."
 echo ""
+
+TMP_ENV_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_ENV_DIR}"' EXIT
 
 for transcript in ${TRANSCRIPT_GLOB}; do
     if [ -f "$transcript" ]; then
         TOTAL=$((TOTAL + 1))
-        echo "Validating JSON syntax: $(basename "$transcript")"
+        base="$(basename "$transcript")"
+        echo "Validating JSON syntax: ${base}"
 
         if command -v python3 >/dev/null 2>&1; then
             SYNTAX_OK=$(python3 -c "import json, sys; json.load(open(sys.argv[1])); print('ok')" "$transcript" 2>/dev/null)
@@ -128,6 +167,47 @@ for transcript in ${TRANSCRIPT_GLOB}; do
         else
             echo "  [X] Invalid JSON"
             exit 1
+        fi
+
+        # If the document has a top-level "messages" array of envelopes,
+        # validate every envelope against the envelope schema.
+        if command -v python3 >/dev/null 2>&1; then
+            MSG_COUNT=$(python3 -c "
+import json, os, sys
+doc = json.load(open(sys.argv[1]))
+# Transcripts may carry envelopes under 'messages' or 'transcript'.
+msgs = doc.get('messages')
+if not isinstance(msgs, list):
+    msgs = doc.get('transcript')
+if not isinstance(msgs, list):
+    print(0); sys.exit(0)
+out_dir = sys.argv[2]
+count = 0
+for i, msg in enumerate(msgs):
+    # Only validate dict entries that look like MACP envelopes
+    # (i.e. have both 'macp_version' and 'message_type').
+    if not (isinstance(msg, dict) and 'macp_version' in msg and 'message_type' in msg):
+        continue
+    with open(os.path.join(out_dir, f'msg_{i:03d}.json'), 'w') as f:
+        json.dump(msg, f)
+    count += 1
+print(count)
+" "$transcript" "${TMP_ENV_DIR}" 2>/dev/null || echo 0)
+
+            if [ "${MSG_COUNT}" -gt 0 ]; then
+                echo "  Validating ${MSG_COUNT} envelope(s) inside ${base}..."
+                for i in $(seq 0 $((MSG_COUNT - 1))); do
+                    idx=$(printf "%03d" "$i")
+                    env_file="${TMP_ENV_DIR}/msg_${idx}.json"
+                    if ! ajv validate -s "${ENVELOPE_SCHEMA}" -d "${env_file}" --spec=draft2020 --strict=false >/dev/null 2>&1; then
+                        echo "  [X] Envelope #${i} in ${base} failed envelope-schema validation:"
+                        ajv validate -s "${ENVELOPE_SCHEMA}" -d "${env_file}" --spec=draft2020 --strict=false || true
+                        exit 1
+                    fi
+                    rm -f "${env_file}"
+                done
+                echo "  [OK] All ${MSG_COUNT} envelopes valid against envelope schema"
+            fi
         fi
         echo ""
     fi


### PR DESCRIPTION
## Summary                                                      
  - Promote passive session subscription into core `StreamSession` semantics (RFC-MACP-0006 §3.2): `StreamSessionRequest` gains `subscribe_session_id` and
  `after_sequence`, with normative authorization, history-replay, and mutual-exclusion rules with `envelope`. Applied to canonical `schemas/proto/macp/v1/core.proto`   
  and mirrored into `packages/proto-npm` and `packages/proto-rust`. RFC bumped to `1.1.0-draft` and `docs/transports.md` rewritten to point at the new normative
  section.                                                                                                                                                              
  - Regenerate Go (`core.pb.go`, `core_grpc.pb.go`, `policy.pb.go`, mode stubs) and Python (`core_pb2_grpc.py`) stubs so they match the canonical proto surface,
  including the already-landed `ListSessions` / `WatchSessions` session-lifecycle RPCs.                                                                                 
  - Add stub-drift CI guards: `scripts/check-go-stubs.sh` and `scripts/check-python-stubs.sh` do a content-normalized diff between committed stubs and a fresh
  generation, with graceful skips when toolchains are missing. Wired into `Makefile` (`check-go-stubs`, `check-python-stubs`, and `validate`) and                       
  `.github/workflows/ci.yml`.                                     
  - Strengthen `scripts/validate-json.sh`: for each composite transcript under `examples/`, every embedded envelope is now validated against `macp-envelope.schema.json`
   in addition to the existing JSON syntax check. Also validates new discovery examples against their schemas.                                                          
  - Add discovery/runtime example payloads — `agent_bootstrap.json`, `run_descriptor.json`, `session_metadata.json`, `session_lifecycle_event.json` — and surface them
  in `docs/examples.md`.                                                                                                                                                
  - Remove `packages/proto-swift` from the raw-proto sync set in `scripts/sync-proto-packages.sh` (package removed upstream).
                                                                                                                                                                        
  ## Why                                                          
  - Runtimes need a standard way for authorized participants/observers to attach to an existing session without mutating it; pseudo-envelope workarounds were explicitly
   disallowed but no replacement was normative.                                                                                                                         
  - Generated Go/Python stubs previously lagged the canonical `.proto` tree, so downstream consumers of `packages/proto-go` and `packages/proto-python` saw stale
  service surfaces. The new CI guards make drift a build failure instead of a silent divergence.                                                                        
  - Transcript validation was syntax-only; per-envelope schema checks catch schema regressions in the example transcripts that ship with the spec.
                                                                                                                                                                        
  ## Test plan                                                    
  - [ ] `make validate` passes locally (runs `json-schema-validate`, `json-validate`, `proto-lint`, `proto-compile`, `check-proto-sync`, `check-python-stubs`,          
  `check-go-stubs`).                                                                                                                                                    
  - [ ] `./scripts/check-go-stubs.sh` exits 0 on a clean tree; intentionally edit a committed `*.pb.go` to confirm it fails with a unified diff.
  - [ ] `./scripts/check-python-stubs.sh` exits 0 on a clean tree; intentionally edit a committed `*_pb2_grpc.py` to confirm it fails.                                  
  - [ ] `./scripts/validate-json.sh` validates every new `examples/discovery/*.json` against its schema, and validates every envelope inside                            
  `examples/*-mode-session.json`.                                                                                                                                       
  - [ ] CI (`.github/workflows/ci.yml`) green end-to-end, including the new Python + Go stub-drift steps.                                                               
  - [ ] Spot-check the new RFC-MACP-0006 §3.2 language and `docs/transports.md` update render correctly in a Markdown preview.   