### PR TITLE
Add session suspension, distinct cancellation state, and commitment supersession

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ An identifiable computational entity that emits and receives MACP Envelopes.
 An ambient, non-binding message carrying informational updates. In the base protocol, Signals carry an empty `session_id` and an empty `mode`; if they need to correlate with a session, that reference belongs inside the payload. Signals MUST NOT create sessions, mutate session state, or produce binding outcomes.
 
 **Coordination Session**  
-A bounded coordination context created only by `SessionStart`, governed by a declared Mode and a monotonic lifecycle, and terminating explicitly as **RESOLVED** or **EXPIRED**.
+A bounded coordination context created only by `SessionStart`, governed by a declared Mode and a monotonic lifecycle, pausable to **SUSPENDED**, and terminating explicitly as **RESOLVED**, **EXPIRED**, or **CANCELLED**.
 
 **MACP Runtime**  
 The logical system responsible for enforcing structural invariants: validation, ordering, deduplication, session lifecycle transitions, isolation, and persistence.
@@ -228,8 +228,9 @@ A session is created only by a valid `SessionStart` message. There is no implici
 Once created, a session is governed by a monotonic lifecycle:
 
 - It starts OPEN.
-- It terminates as RESOLVED (Mode-defined terminal condition) or EXPIRED (TTL/cancellation/policy).
-- It can never return to OPEN.
+- It may be paused to SUSPENDED (non-terminal) and resumed to OPEN.
+- It terminates as RESOLVED (Mode-defined terminal condition), EXPIRED (TTL/policy), or CANCELLED (CancelSession).
+- Once terminal, it can never return to OPEN.
 
 ### 6.1 Session-scoped communication rule
 
@@ -251,13 +252,18 @@ stateDiagram-v2
 
   NON_EXISTENT --> OPEN: accept SessionStart
 
+  OPEN --> SUSPENDED: SuspendSession (TTL banked)
+  SUSPENDED --> OPEN: ResumeSession (TTL restored)
   OPEN --> RESOLVED: accept first terminal message
   OPEN --> EXPIRED: TTL elapsed
-  OPEN --> EXPIRED: CancelSession
   OPEN --> EXPIRED: runtime policy
+  SUSPENDED --> EXPIRED: banked TTL / MAX_SUSPEND_MS
+  OPEN --> CANCELLED: CancelSession
+  SUSPENDED --> CANCELLED: CancelSession
 
   RESOLVED --> [*]
   EXPIRED --> [*]
+  CANCELLED --> [*]
 ```
 
 ### 7.1 Acceptance rules in OPEN
@@ -518,7 +524,7 @@ A system that can never force a session to terminate cannot guarantee coherence 
 
 Cancellation is where many systems degrade into ambiguity. MACP treats cancellation as structural.
 
-A compliant runtime MUST support deterministic cancellation that transitions a session from OPEN to EXPIRED without mutating history. By default, only the session initiator is authorized to cancel. Deployments MAY extend cancellation authority through policy.
+A compliant runtime MUST support deterministic cancellation that transitions a session to the terminal CANCELLED state (distinct from EXPIRED) without mutating history. By default, only the session initiator is authorized to cancel. Deployments MAY extend cancellation authority through policy.
 
 A runtime SHOULD emit a session-scoped cancellation event (`SessionCancel` Envelope) into the append-only log so that replay preserves the cause of termination.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -8,18 +8,26 @@ The MACP session lifecycle is a monotonic state machine. This is what turns coor
 ## Session states
 
 - **OPEN** — session is active and accepting messages
+- **SUSPENDED** — non-terminal pause of an OPEN session (TTL is banked); resumes to OPEN
 - **RESOLVED** — session terminated via first accepted Mode-defined terminal message
-- **EXPIRED** — session terminated due to TTL, cancellation, or deterministic runtime policy
+- **EXPIRED** — session terminated due to TTL or deterministic runtime policy
+- **CANCELLED** — session terminated by an accepted `CancelSession` (distinct from EXPIRED)
 
-No transition from RESOLVED or EXPIRED back to OPEN is permitted.
+`RESOLVED`, `EXPIRED`, and `CANCELLED` are terminal; no transition out of a terminal state is permitted. `SUSPENDED` is a non-terminal pause: only `OPEN`↔`SUSPENDED` and `SUSPENDED`→`EXPIRED` are allowed, and a commitment can only be emitted from `OPEN` (so a suspended session must be resumed before it can resolve). See [RFC-MACP-0001 §7.2/§7.5](../rfcs/RFC-MACP-0001-core.md).
 
 ```mermaid
 stateDiagram-v2
   [*] --> OPEN: SessionStart accepted
+  OPEN --> SUSPENDED: SuspendSession (TTL banked)
+  SUSPENDED --> OPEN: ResumeSession (TTL restored)
   OPEN --> RESOLVED: first accepted terminal message
-  OPEN --> EXPIRED: TTL / CancelSession / deterministic runtime policy
+  OPEN --> EXPIRED: TTL / deterministic runtime policy
+  SUSPENDED --> EXPIRED: banked TTL / MAX_SUSPEND_MS exceeded
+  OPEN --> CANCELLED: CancelSession accepted
+  SUSPENDED --> CANCELLED: CancelSession accepted
   RESOLVED --> [*]
   EXPIRED --> [*]
+  CANCELLED --> [*]
 ```
 
 ## Admission rules for session-scoped messages
@@ -46,7 +54,15 @@ All validation, authentication, authorization, deduplication, session-state chec
 
 ## Cancellation Authority
 
-The default cancellation authority is the session initiator. Deployments may extend this through policy, but cancellation always requires authentication and authorization.
+The default cancellation authority is the session initiator. Deployments may extend this through policy, but cancellation always requires authentication and authorization. An accepted `CancelSession` transitions the session to the terminal **CANCELLED** state (distinct from EXPIRED) and appends a `SessionCancel` annotation to the accepted history.
+
+## Suspension and Resume
+
+An OPEN session can be paused and later resumed via the `SuspendSession` and `ResumeSession` control-plane RPCs (same authority model as `CancelSession`; see [RFC-MACP-0001 §7.5](../rfcs/RFC-MACP-0001-core.md)). While **SUSPENDED**, the session rejects Mode messages (it is not OPEN) and its TTL is *banked* rather than running: suspend records the remaining time, resume restores it (`SessionResumePayload.banked_ms`). A fixed `MAX_SUSPEND_MS` cap bounds indefinite pauses — exceeding it expires the session. Because suspend/resume are recorded events on the append-only history, a suspended-then-resumed session replays to the identical terminal state ([RFC-MACP-0003 §2](../rfcs/RFC-MACP-0003-determinism.md)).
+
+## Commitment Supersession
+
+A `CommitmentPayload` may carry a `supersedes` reference (`{session_id, commitment_hash}`) marking it as a revision of an earlier commitment. Since a RESOLVED session accepts no further messages, a superseding commitment lives in a **new** session pointing back at the prior one — supersession is inherently cross-session. The runtime only checks structural well-formedness and this-session authority; chain resolution and supersession policy are consumer governance ([RFC-MACP-0001 §7.3.1](../rfcs/RFC-MACP-0001-core.md)).
 
 ## Terminal races
 
@@ -57,7 +73,7 @@ If multiple terminal messages are sent concurrently, the first one accepted into
 Two RPCs provide programmatic session lifecycle observation:
 
 - **`ListSessions`** — returns `SessionMetadata` for all known sessions. Use for initial sync. Advertised by `sessions.list_sessions`.
-- **`WatchSessions`** — server-streaming RPC that emits `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED) in real time. Advertised by `sessions.watch_sessions`.
+- **`WatchSessions`** — server-streaming RPC that emits `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED, SUSPENDED, RESUMED, CANCELLED) in real time. Advertised by `sessions.watch_sessions`.
 
 Control-planes and UIs typically call `ListSessions` on startup for a snapshot, then subscribe to `WatchSessions` for incremental updates. Events are ephemeral and not replayed.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -59,4 +59,8 @@ Because accepted session history is append-only, failed owners can recover by re
 
 ## Cancellation
 
-Cancellation transitions a session from OPEN to EXPIRED without rewriting history. By default, only the session initiator is authorized to cancel. Deployments may extend this through policy. Late-arriving messages are rejected because the lifecycle state is no longer OPEN.
+Cancellation transitions a session to the terminal **CANCELLED** state — distinct from EXPIRED (TTL / runtime policy) — without rewriting history. By default, only the session initiator is authorized to cancel. Deployments may extend this through policy. Late-arriving messages are rejected because the lifecycle state is no longer OPEN.
+
+## Suspension and Resume
+
+An OPEN session may be paused to **SUSPENDED** via `SuspendSession` and later returned to OPEN via `ResumeSession` (same authority model as cancellation; see [RFC-MACP-0001 §7.5](../rfcs/RFC-MACP-0001-core.md)). A suspended session rejects Mode messages and banks its TTL — the remaining time is recorded on suspend and restored on resume — so a held session does not silently expire. A `MAX_SUSPEND_MS` cap bounds indefinite pauses. Suspend and resume are recorded as accepted-history annotations, keeping the suspension timeline deterministic under replay.

--- a/packages/proto-npm/package.json
+++ b/packages/proto-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiagentcoordinationprotocol/proto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MACP protocol buffer definitions — raw .proto files for the Multi-Agent Coordination Protocol",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/proto-npm/proto/macp/v1/core.proto
+++ b/packages/proto-npm/proto/macp/v1/core.proto
@@ -126,6 +126,35 @@ message SessionCancelPayload {
   string cancelled_by = 2;
 }
 
+// Appended to accepted history by the runtime when a SuspendSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC;
+// the runtime is the sole emitter.
+message SessionSuspendPayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of SuspendSession.
+  string suspended_by = 2;
+}
+
+// Appended to accepted history by the runtime when a ResumeSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC.
+message SessionResumePayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of ResumeSession.
+  string resumed_by = 2;
+  // Milliseconds of TTL banked during the suspension and restored to the
+  // session's absolute deadline on resume (RFC-MACP-0003 §2).
+  int64 banked_ms = 3;
+}
+
+// Reference to a specific accepted commitment, used for cross-session
+// supersession (RFC-MACP-0001 §7.3).
+message CommitmentRef {
+  string session_id = 1;
+  // Content hash of the superseded CommitmentPayload (an implementation-defined
+  // digest over its canonical encoding).
+  string commitment_hash = 2;
+}
+
 message CommitmentPayload {
   string commitment_id = 1;
   // Action identifier describing the outcome (e.g., "decision.approved",
@@ -141,6 +170,13 @@ message CommitmentPayload {
   // false for definitive negative outcomes (e.g., rejection, failure).
   // Modes that allow negative commitments MUST set this field explicitly.
   bool outcome_positive = 8;
+  // Cross-session supersession (RFC-MACP-0001 §7.3): when present, this
+  // commitment supersedes a prior commitment identified by {session_id,
+  // commitment_hash}. The superseding commitment lives in a NEW session (a
+  // RESOLVED session accepts no further messages). The kernel validates only
+  // structural well-formedness and this-session authority; chain resolution and
+  // whether supersession is permitted are consumer governance.
+  CommitmentRef supersedes = 9;
 }
 
 message ParticipantActivity {
@@ -178,6 +214,27 @@ message GetSessionRequest {
 message CancelSessionRequest {
   string session_id = 1;
   string reason = 2;
+}
+
+// Session suspension / resume (RFC-MACP-0001 §7.5). Symmetric with
+// CancelSession: a Core control-plane RPC restricted to the initiator and
+// policy-delegated roles.
+message SuspendSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message SuspendSessionResponse {
+  Ack ack = 1;
+}
+
+message ResumeSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message ResumeSessionResponse {
+  Ack ack = 1;
 }
 
 // Empty agent_id requests the manifest of the serving runtime/agent.
@@ -356,6 +413,9 @@ message SessionLifecycleEvent {
     EVENT_TYPE_CREATED = 1;
     EVENT_TYPE_RESOLVED = 2;
     EVENT_TYPE_EXPIRED = 3;
+    EVENT_TYPE_SUSPENDED = 4;
+    EVENT_TYPE_RESUMED = 5;
+    EVENT_TYPE_CANCELLED = 6;
   }
   EventType event_type = 1;
   SessionMetadata session = 2;
@@ -372,6 +432,9 @@ service MACPRuntimeService {
   rpc StreamSession(stream StreamSessionRequest) returns (stream StreamSessionResponse);
   rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse);
+  // Session suspension / resume (RFC-MACP-0001 §7.5)
+  rpc SuspendSession(SuspendSessionRequest) returns (SuspendSessionResponse);
+  rpc ResumeSession(ResumeSessionRequest) returns (ResumeSessionResponse);
   rpc GetManifest(GetManifestRequest) returns (GetManifestResponse);
   rpc ListModes(ListModesRequest) returns (ListModesResponse);
   rpc WatchModeRegistry(WatchModeRegistryRequest) returns (stream WatchModeRegistryResponse);

--- a/packages/proto-npm/proto/macp/v1/envelope.proto
+++ b/packages/proto-npm/proto/macp/v1/envelope.proto
@@ -28,6 +28,15 @@ enum SessionState {
   SESSION_STATE_OPEN = 1;
   SESSION_STATE_RESOLVED = 2;
   SESSION_STATE_EXPIRED = 3;
+  // Session paused by an accepted SuspendSession RPC (RFC-MACP-0001 §7.5).
+  // Non-terminal: TTL is banked while suspended and restored on ResumeSession.
+  // Only OPEN<->SUSPENDED and SUSPENDED->EXPIRED transitions are permitted; a
+  // commitment may only be emitted from OPEN, so SUSPENDED->RESOLVED is not.
+  SESSION_STATE_SUSPENDED = 4;
+  // Terminal state for a session ended by an accepted CancelSession RPC
+  // (RFC-MACP-0001 §7.3). Distinct from EXPIRED (TTL / deterministic runtime
+  // policy) so consumers can tell explicit cancellation from expiry.
+  SESSION_STATE_CANCELLED = 5;
 }
 
 message Ack {

--- a/packages/proto-rust/Cargo.toml
+++ b/packages/proto-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macp-proto"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "MACP protocol buffer definitions for the Multi-Agent Coordination Protocol"
 license = "Apache-2.0"

--- a/packages/proto-rust/proto/macp/v1/core.proto
+++ b/packages/proto-rust/proto/macp/v1/core.proto
@@ -126,6 +126,35 @@ message SessionCancelPayload {
   string cancelled_by = 2;
 }
 
+// Appended to accepted history by the runtime when a SuspendSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC;
+// the runtime is the sole emitter.
+message SessionSuspendPayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of SuspendSession.
+  string suspended_by = 2;
+}
+
+// Appended to accepted history by the runtime when a ResumeSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC.
+message SessionResumePayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of ResumeSession.
+  string resumed_by = 2;
+  // Milliseconds of TTL banked during the suspension and restored to the
+  // session's absolute deadline on resume (RFC-MACP-0003 §2).
+  int64 banked_ms = 3;
+}
+
+// Reference to a specific accepted commitment, used for cross-session
+// supersession (RFC-MACP-0001 §7.3).
+message CommitmentRef {
+  string session_id = 1;
+  // Content hash of the superseded CommitmentPayload (an implementation-defined
+  // digest over its canonical encoding).
+  string commitment_hash = 2;
+}
+
 message CommitmentPayload {
   string commitment_id = 1;
   // Action identifier describing the outcome (e.g., "decision.approved",
@@ -141,6 +170,13 @@ message CommitmentPayload {
   // false for definitive negative outcomes (e.g., rejection, failure).
   // Modes that allow negative commitments MUST set this field explicitly.
   bool outcome_positive = 8;
+  // Cross-session supersession (RFC-MACP-0001 §7.3): when present, this
+  // commitment supersedes a prior commitment identified by {session_id,
+  // commitment_hash}. The superseding commitment lives in a NEW session (a
+  // RESOLVED session accepts no further messages). The kernel validates only
+  // structural well-formedness and this-session authority; chain resolution and
+  // whether supersession is permitted are consumer governance.
+  CommitmentRef supersedes = 9;
 }
 
 message ParticipantActivity {
@@ -178,6 +214,27 @@ message GetSessionRequest {
 message CancelSessionRequest {
   string session_id = 1;
   string reason = 2;
+}
+
+// Session suspension / resume (RFC-MACP-0001 §7.5). Symmetric with
+// CancelSession: a Core control-plane RPC restricted to the initiator and
+// policy-delegated roles.
+message SuspendSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message SuspendSessionResponse {
+  Ack ack = 1;
+}
+
+message ResumeSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message ResumeSessionResponse {
+  Ack ack = 1;
 }
 
 // Empty agent_id requests the manifest of the serving runtime/agent.
@@ -356,6 +413,9 @@ message SessionLifecycleEvent {
     EVENT_TYPE_CREATED = 1;
     EVENT_TYPE_RESOLVED = 2;
     EVENT_TYPE_EXPIRED = 3;
+    EVENT_TYPE_SUSPENDED = 4;
+    EVENT_TYPE_RESUMED = 5;
+    EVENT_TYPE_CANCELLED = 6;
   }
   EventType event_type = 1;
   SessionMetadata session = 2;
@@ -372,6 +432,9 @@ service MACPRuntimeService {
   rpc StreamSession(stream StreamSessionRequest) returns (stream StreamSessionResponse);
   rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse);
+  // Session suspension / resume (RFC-MACP-0001 §7.5)
+  rpc SuspendSession(SuspendSessionRequest) returns (SuspendSessionResponse);
+  rpc ResumeSession(ResumeSessionRequest) returns (ResumeSessionResponse);
   rpc GetManifest(GetManifestRequest) returns (GetManifestResponse);
   rpc ListModes(ListModesRequest) returns (ListModesResponse);
   rpc WatchModeRegistry(WatchModeRegistryRequest) returns (stream WatchModeRegistryResponse);

--- a/packages/proto-rust/proto/macp/v1/envelope.proto
+++ b/packages/proto-rust/proto/macp/v1/envelope.proto
@@ -28,6 +28,15 @@ enum SessionState {
   SESSION_STATE_OPEN = 1;
   SESSION_STATE_RESOLVED = 2;
   SESSION_STATE_EXPIRED = 3;
+  // Session paused by an accepted SuspendSession RPC (RFC-MACP-0001 §7.5).
+  // Non-terminal: TTL is banked while suspended and restored on ResumeSession.
+  // Only OPEN<->SUSPENDED and SUSPENDED->EXPIRED transitions are permitted; a
+  // commitment may only be emitted from OPEN, so SUSPENDED->RESOLVED is not.
+  SESSION_STATE_SUSPENDED = 4;
+  // Terminal state for a session ended by an accepted CancelSession RPC
+  // (RFC-MACP-0001 §7.3). Distinct from EXPIRED (TTL / deterministic runtime
+  // policy) so consumers can tell explicit cancellation from expiry.
+  SESSION_STATE_CANCELLED = 5;
 }
 
 message Ack {

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -199,13 +199,27 @@ A Mode MAY also bind additional immutable authority roles through the accepted `
 
 ### 7.2 Session States
 
-Core defines three states:
+Core defines five states:
 
 - `OPEN`
-- `RESOLVED`
-- `EXPIRED`
+- `SUSPENDED` — non-terminal pause of an `OPEN` session (see §7.5)
+- `RESOLVED` — terminal
+- `EXPIRED` — terminal
+- `CANCELLED` — terminal
 
-Sessions MUST transition monotonically. No transition from RESOLVED or EXPIRED back to OPEN is permitted.
+`RESOLVED`, `EXPIRED`, and `CANCELLED` are terminal. Sessions MUST transition monotonically with respect to termination: once a session is terminal, no further transition is permitted (in particular, no transition back to `OPEN` or `SUSPENDED`).
+
+`SUSPENDED` is a non-terminal pause of an `OPEN` session. The complete set of permitted transitions is:
+
+- `OPEN → SUSPENDED` and `SUSPENDED → OPEN` — suspend / resume (§7.5),
+- `OPEN → RESOLVED` — the first Mode-defined terminal condition is accepted (§7.3),
+- `OPEN → EXPIRED` — TTL elapses or deterministic runtime policy requires expiration (§7.3),
+- `SUSPENDED → EXPIRED` — the suspended session's banked TTL elapses or `MAX_SUSPEND_MS` is exceeded (§7.5),
+- `OPEN → CANCELLED` and `SUSPENDED → CANCELLED` — a `CancelSession` request is accepted (§7.3).
+
+A commitment (the Mode terminal condition) MUST be emitted only from `OPEN`. Therefore `SUSPENDED → RESOLVED` is NOT permitted: a session MUST be resumed to `OPEN` before it can resolve. No transition out of a terminal state is permitted.
+
+> **Breaking change (v1.0.0-draft):** Two states were added to the lifecycle — `SUSPENDED` (§7.5) and `CANCELLED` — and cancellation now terminates a session as `CANCELLED` rather than `EXPIRED`. This is a wire- and behavior-breaking change to the session state machine; runtimes and observers MUST handle the new `SessionState`/`SessionLifecycleEvent` values. No backward-compatibility shim is provided.
 
 ### 7.3 Termination
 
@@ -219,17 +233,24 @@ A session transitions from OPEN to RESOLVED when the first Mode-defined terminal
 
 A session transitions from OPEN to EXPIRED when:
 
-- TTL elapses,
-- cancellation is accepted,
-- or deterministic runtime policy requires expiration.
+- TTL elapses (including a suspended session's banked TTL, §7.5), or
+- deterministic runtime policy requires expiration.
+
+A session transitions to CANCELLED (from OPEN or SUSPENDED) when a `CancelSession` request is accepted. `CANCELLED` is a distinct terminal state from `EXPIRED`, so observers can tell an explicit cancellation apart from TTL/policy expiry.
 
 Any session-scoped message referencing a non-OPEN session MUST be rejected.
 
 By default, only the accepted `SessionStart` sender (session initiator) is authorized to submit `CancelSession` for that session. The runtime MUST record the initiator in `SessionMetadata.initiator` at session creation time for authorization checks. Deployments MAY extend cancellation authority to additional roles through policy. `CancelSession` MUST be subject to the same authentication requirements as any session-scoped operation.
 
-`CancelSession` is the client-facing RPC. Upon accepting a `CancelSession` request, the runtime MUST append a `SessionCancel` envelope (with `SessionCancelPayload`) to the session's accepted history as a terminal annotation. `SessionCancel` envelopes MUST NOT be submitted directly via the `Send` RPC; the runtime is the sole emitter.
+`CancelSession` is the client-facing RPC. Upon accepting a `CancelSession` request, the runtime MUST transition the session to CANCELLED and append a `SessionCancel` envelope (with `SessionCancelPayload`) to the session's accepted history as a terminal annotation. `SessionCancel` envelopes MUST NOT be submitted directly via the `Send` RPC; the runtime is the sole emitter.
 
 `CancelSession` is a Core control-plane message. Mode-specific authorization rules (e.g., who can emit which Mode message type) do NOT apply to `CancelSession`. Only the initiator and policy-delegated roles may cancel a session.
+
+#### 7.3.1 Commitment Supersession
+
+`CommitmentPayload` MAY carry a `supersedes` field (`CommitmentRef { session_id, commitment_hash }`) indicating that this commitment revises an earlier one. Because a `RESOLVED` session accepts no further session-scoped messages (step 5 above), a superseding commitment cannot live in the same session as the commitment it supersedes: it is emitted in a **new** session whose `supersedes` reference points back at the earlier commitment. Supersession is therefore inherently **cross-session**.
+
+The runtime's structural obligations are limited to: (a) if `supersedes` is present, its fields MUST be well-formed (non-empty `session_id` and `commitment_hash`); and (b) the superseding party MUST be authorized in the new session under the normal authority rules. The runtime MUST NOT, as a Core obligation, resolve the reference, verify that the referenced commitment exists, or decide whether the supersession is *permitted* — those are cross-session concerns. Chain resolution ("the current commitment for this matter"), supersession policy, and fork handling (whether two live successors to one commitment are allowed) are consumer governance built above Core, which MAY maintain a cross-session commitment index for the purpose. A consumer that does not use supersession is unaffected; the field is simply absent.
 
 ### 7.4 Session Context and Extensions
 
@@ -256,6 +277,21 @@ Observers (including control-planes and UIs) MAY use `context_id` for indexing, 
 **Naming convention (RECOMMENDED):** Extension keys SHOULD use dot-separated reverse-domain notation for public protocols (e.g., `ctxm.v1`, `aitp.v1`) and `x-` prefix for deployment-private extensions (e.g., `x-billing`, `x-tracing`).
 
 > **Migration note:** The former opaque `bytes context` field (field 7) has been removed from `SessionStartPayload`. It is superseded by the structured `context_id` (field 8) and `extensions` (field 9) fields. The `roots` field has been renumbered from field 8 to field 7.
+
+### 7.5 Suspension and Resume
+
+An `OPEN` session MAY be paused into the `SUSPENDED` state and later resumed to `OPEN`. Suspension is the Core mechanism behind human-in-the-loop and operational holds: a session that is paused for review MUST replay identically for every consumer.
+
+**Control-plane RPCs.** `SuspendSession` and `ResumeSession` are Core control-plane RPCs, symmetric with `CancelSession`:
+
+- `SuspendSession` is accepted only when the session is `OPEN`; it transitions the session to `SUSPENDED`.
+- `ResumeSession` is accepted only when the session is `SUSPENDED`; it transitions the session back to `OPEN`.
+
+Like `CancelSession`, they are restricted to the session initiator and policy-delegated roles, are subject to the same authentication requirements, and are NOT governed by Mode-specific authorization rules. Upon accepting a `SuspendSession` request the runtime MUST append a `SessionSuspend` envelope (with `SessionSuspendPayload`); upon accepting a `ResumeSession` request it MUST append a `SessionResume` envelope (with `SessionResumePayload`). These envelopes MUST NOT be submitted via the `Send` RPC — the runtime is the sole emitter — and they enter the accepted history so the suspension timeline is part of the replayed record.
+
+**Acceptance while suspended.** A `SUSPENDED` session is not `OPEN`; therefore any session-scoped Mode message (Proposal, Vote, Commitment, …) referencing it MUST be rejected with a non-OPEN session error, exactly as for terminal sessions (§7.3). Only `ResumeSession` (and `CancelSession`) may be accepted against a `SUSPENDED` session.
+
+**Pausable TTL.** The session's absolute deadline is banked across suspension rather than continuing to run. On suspend, the runtime records the remaining time `banked = deadline − suspend_time`; on resume, it sets `deadline = resume_time + banked` (the resume's `banked_ms` records this value for replay). A `SUSPENDED` session MUST NOT expire on its pre-suspension deadline. To bound indefinite pauses, a runtime MUST enforce a `MAX_SUSPEND_MS` cap: if the cumulative suspended duration exceeds the cap, the session transitions `SUSPENDED → EXPIRED`. TTL accounting under suspension is normatively deterministic — see RFC-MACP-0003 §2.
 
 ---
 
@@ -470,7 +506,7 @@ MACP supports extensibility in three primary ways:
 Extensions MUST preserve Core invariants:
 
 - explicit session boundaries,
-- monotonic lifecycle,
+- monotonic lifecycle — terminal states (`RESOLVED`, `EXPIRED`, `CANCELLED`) are final; the non-terminal `OPEN`↔`SUSPENDED` pause (§7.5) does not violate this,
 - append-only accepted history,
 - session isolation,
 - replay-preserving acceptance order.

--- a/rfcs/RFC-MACP-0003-determinism.md
+++ b/rfcs/RFC-MACP-0003-determinism.md
@@ -39,11 +39,13 @@ Core guarantees determinism for:
 - session lifecycle transitions,
 - within-session acceptance order,
 - idempotent handling of duplicate `message_id` values,
-- the terminal lifecycle state (RESOLVED or EXPIRED) when the accepted history is identical.
+- the terminal lifecycle state (RESOLVED, EXPIRED, or CANCELLED) when the accepted history is identical.
 
 Core does not guarantee semantic determinism unless the Mode claims it.
 
-`timestamp_unix_ms` is informational for ordering and display purposes and MUST NOT be used for message acceptance decisions. However, `timestamp_unix_ms` on the `SessionStart` envelope is normative for TTL computation: the session's absolute expiration deadline is computed as `SessionStart_envelope.timestamp_unix_ms + SessionStartPayload.ttl_ms`. During replay, the runtime MUST use this pre-computed deadline from the original session, not wall-clock time. If the TTL has elapsed before a terminal condition is accepted, the session transitions to EXPIRED.
+`timestamp_unix_ms` is informational for ordering and display purposes and MUST NOT be used for message acceptance decisions. However, `timestamp_unix_ms` on the `SessionStart` envelope is normative for TTL computation: the session's initial absolute expiration deadline is computed as `SessionStart_envelope.timestamp_unix_ms + SessionStartPayload.ttl_ms`. During replay, the runtime MUST derive the deadline from the original session timeline, not wall-clock time. If the TTL has elapsed before a terminal condition is accepted, the session transitions to EXPIRED.
+
+**TTL under suspension (RFC-MACP-0001 §7.5).** Suspension banks the remaining TTL rather than letting the deadline keep running, so the deadline depends on the suspend/resume timeline. This is deterministic precisely because suspend and resume are accepted, recorded events on the session's append-only history: each `SessionSuspend`/`SessionResume` envelope carries the `timestamp_unix_ms` Core uses for accounting. On suspend at time `t_s`, the runtime banks `banked = deadline − t_s`; on resume at time `t_r`, it sets `deadline = t_r + banked` (recorded in `SessionResumePayload.banked_ms`). A `SUSPENDED` session MUST NOT expire on its pre-suspension deadline. To bound indefinite pauses, the runtime MUST enforce a fixed `MAX_SUSPEND_MS` cap: if cumulative suspended duration exceeds the cap, the session transitions `SUSPENDED → EXPIRED`. Because every input to this computation (`MAX_SUSPEND_MS` and the suspend/resume event timestamps) is on the replayed timeline, replay reconstructs the identical adjusted deadline and the identical terminal state — the determinism guarantee above holds for suspended-then-resumed sessions.
 
 ## 3. Version Binding
 

--- a/schemas/json/macp-ack.schema.json
+++ b/schemas/json/macp-ack.schema.json
@@ -32,7 +32,9 @@
         "SESSION_STATE_UNSPECIFIED",
         "SESSION_STATE_OPEN",
         "SESSION_STATE_RESOLVED",
-        "SESSION_STATE_EXPIRED"
+        "SESSION_STATE_EXPIRED",
+        "SESSION_STATE_SUSPENDED",
+        "SESSION_STATE_CANCELLED"
       ],
       "description": "Session lifecycle state after accepting the message."
     },

--- a/schemas/json/macp-session-lifecycle-event.schema.json
+++ b/schemas/json/macp-session-lifecycle-event.schema.json
@@ -15,7 +15,10 @@
         "EVENT_TYPE_UNSPECIFIED",
         "EVENT_TYPE_CREATED",
         "EVENT_TYPE_RESOLVED",
-        "EVENT_TYPE_EXPIRED"
+        "EVENT_TYPE_EXPIRED",
+        "EVENT_TYPE_SUSPENDED",
+        "EVENT_TYPE_RESUMED",
+        "EVENT_TYPE_CANCELLED"
       ],
       "description": "The type of session lifecycle event."
     },
@@ -28,7 +31,7 @@
         "mode": { "type": "string" },
         "state": {
           "type": "string",
-          "enum": ["SESSION_STATE_UNSPECIFIED", "SESSION_STATE_OPEN", "SESSION_STATE_RESOLVED", "SESSION_STATE_EXPIRED"]
+          "enum": ["SESSION_STATE_UNSPECIFIED", "SESSION_STATE_OPEN", "SESSION_STATE_RESOLVED", "SESSION_STATE_EXPIRED", "SESSION_STATE_SUSPENDED", "SESSION_STATE_CANCELLED"]
         }
       }
     },

--- a/schemas/json/macp-session-metadata.schema.json
+++ b/schemas/json/macp-session-metadata.schema.json
@@ -30,7 +30,9 @@
         "SESSION_STATE_UNSPECIFIED",
         "SESSION_STATE_OPEN",
         "SESSION_STATE_RESOLVED",
-        "SESSION_STATE_EXPIRED"
+        "SESSION_STATE_EXPIRED",
+        "SESSION_STATE_SUSPENDED",
+        "SESSION_STATE_CANCELLED"
       ],
       "description": "Current session lifecycle state."
     },

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -126,6 +126,35 @@ message SessionCancelPayload {
   string cancelled_by = 2;
 }
 
+// Appended to accepted history by the runtime when a SuspendSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC;
+// the runtime is the sole emitter.
+message SessionSuspendPayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of SuspendSession.
+  string suspended_by = 2;
+}
+
+// Appended to accepted history by the runtime when a ResumeSession RPC is
+// accepted (RFC-MACP-0001 §7.5). Clients MUST NOT submit this via the Send RPC.
+message SessionResumePayload {
+  string reason = 1;
+  // Set by the runtime; MUST match the authenticated sender of ResumeSession.
+  string resumed_by = 2;
+  // Milliseconds of TTL banked during the suspension and restored to the
+  // session's absolute deadline on resume (RFC-MACP-0003 §2).
+  int64 banked_ms = 3;
+}
+
+// Reference to a specific accepted commitment, used for cross-session
+// supersession (RFC-MACP-0001 §7.3).
+message CommitmentRef {
+  string session_id = 1;
+  // Content hash of the superseded CommitmentPayload (an implementation-defined
+  // digest over its canonical encoding).
+  string commitment_hash = 2;
+}
+
 message CommitmentPayload {
   string commitment_id = 1;
   // Action identifier describing the outcome (e.g., "decision.approved",
@@ -141,6 +170,13 @@ message CommitmentPayload {
   // false for definitive negative outcomes (e.g., rejection, failure).
   // Modes that allow negative commitments MUST set this field explicitly.
   bool outcome_positive = 8;
+  // Cross-session supersession (RFC-MACP-0001 §7.3): when present, this
+  // commitment supersedes a prior commitment identified by {session_id,
+  // commitment_hash}. The superseding commitment lives in a NEW session (a
+  // RESOLVED session accepts no further messages). The kernel validates only
+  // structural well-formedness and this-session authority; chain resolution and
+  // whether supersession is permitted are consumer governance.
+  CommitmentRef supersedes = 9;
 }
 
 message ParticipantActivity {
@@ -178,6 +214,27 @@ message GetSessionRequest {
 message CancelSessionRequest {
   string session_id = 1;
   string reason = 2;
+}
+
+// Session suspension / resume (RFC-MACP-0001 §7.5). Symmetric with
+// CancelSession: a Core control-plane RPC restricted to the initiator and
+// policy-delegated roles.
+message SuspendSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message SuspendSessionResponse {
+  Ack ack = 1;
+}
+
+message ResumeSessionRequest {
+  string session_id = 1;
+  string reason = 2;
+}
+
+message ResumeSessionResponse {
+  Ack ack = 1;
 }
 
 // Empty agent_id requests the manifest of the serving runtime/agent.
@@ -356,6 +413,9 @@ message SessionLifecycleEvent {
     EVENT_TYPE_CREATED = 1;
     EVENT_TYPE_RESOLVED = 2;
     EVENT_TYPE_EXPIRED = 3;
+    EVENT_TYPE_SUSPENDED = 4;
+    EVENT_TYPE_RESUMED = 5;
+    EVENT_TYPE_CANCELLED = 6;
   }
   EventType event_type = 1;
   SessionMetadata session = 2;
@@ -372,6 +432,9 @@ service MACPRuntimeService {
   rpc StreamSession(stream StreamSessionRequest) returns (stream StreamSessionResponse);
   rpc GetSession(GetSessionRequest) returns (GetSessionResponse);
   rpc CancelSession(CancelSessionRequest) returns (CancelSessionResponse);
+  // Session suspension / resume (RFC-MACP-0001 §7.5)
+  rpc SuspendSession(SuspendSessionRequest) returns (SuspendSessionResponse);
+  rpc ResumeSession(ResumeSessionRequest) returns (ResumeSessionResponse);
   rpc GetManifest(GetManifestRequest) returns (GetManifestResponse);
   rpc ListModes(ListModesRequest) returns (ListModesResponse);
   rpc WatchModeRegistry(WatchModeRegistryRequest) returns (stream WatchModeRegistryResponse);

--- a/schemas/proto/macp/v1/envelope.proto
+++ b/schemas/proto/macp/v1/envelope.proto
@@ -28,6 +28,15 @@ enum SessionState {
   SESSION_STATE_OPEN = 1;
   SESSION_STATE_RESOLVED = 2;
   SESSION_STATE_EXPIRED = 3;
+  // Session paused by an accepted SuspendSession RPC (RFC-MACP-0001 §7.5).
+  // Non-terminal: TTL is banked while suspended and restored on ResumeSession.
+  // Only OPEN<->SUSPENDED and SUSPENDED->EXPIRED transitions are permitted; a
+  // commitment may only be emitted from OPEN, so SUSPENDED->RESOLVED is not.
+  SESSION_STATE_SUSPENDED = 4;
+  // Terminal state for a session ended by an accepted CancelSession RPC
+  // (RFC-MACP-0001 §7.3). Distinct from EXPIRED (TTL / deterministic runtime
+  // policy) so consumers can tell explicit cancellation from expiry.
+  SESSION_STATE_CANCELLED = 5;
 }
 
 message Ack {


### PR DESCRIPTION
## Summary

Extends the MACP session lifecycle and commitment model with **session suspension**, a **distinct cancellation state**, and **cross-session commitment supersession**. Spec-only change (proto + RFC + JSON schemas + docs). Proto packages are bumped to **0.2.0**.

## Changes

### Session lifecycle — two new states
- **SUSPENDED** (non-terminal): an OPEN session can be paused via the new `SuspendSession` RPC and resumed via `ResumeSession`. While suspended the session rejects Mode messages and its TTL is *banked* — remaining time is recorded on suspend and restored on resume — bounded by a `MAX_SUSPEND_MS` cap. Suspend/resume are accepted-history annotations, so a held session replays to the identical terminal state.
- **CANCELLED** (terminal): `CancelSession` now terminates a session as CANCELLED instead of EXPIRED, distinguishing explicit cancellation from TTL/policy expiry.

### Commitment supersession
- `CommitmentPayload.supersedes` (`CommitmentRef{session_id, commitment_hash}`) marks a commitment as a revision of an earlier one. Supersession is inherently cross-session (a RESOLVED session accepts no further messages), so the superseding commitment lives in a new session pointing back. The runtime checks only structural well-formedness + this-session authority; chain resolution and supersession policy are consumer governance.

## Surfaces touched
- **Proto** (all three trees — proto-rust, proto-npm, schemas/proto): `SessionState` += SUSPENDED/CANCELLED; `SessionLifecycleEvent.EventType` += SUSPENDED/RESUMED/CANCELLED; new `CommitmentRef`, `SessionSuspendPayload`, `SessionResumePayload`; `SuspendSession`/`ResumeSession` RPCs.
- **RFC-MACP-0001-core**: §7.2 (five-state machine + transition set), §7.3 (cancellation → CANCELLED), §7.3.1 (commitment supersession), §7.5 (suspension & resume), §15 (monotonicity invariant clarified).
- **RFC-MACP-0003-determinism**: §2 — TTL-under-suspension determinism (banked TTL via recorded suspend/resume events).
- **JSON schemas**: session-metadata, ack, session-lifecycle-event enums.
- **Docs**: lifecycle, runtime, architecture (state lists + diagrams).

`buf build` and `buf lint` are clean; JSON schemas validate.

## Compatibility
Breaking change to the session state machine and cancellation semantics. No backward-compatibility shim is provided — intentional at this stage.
