### PR TITLE
Align proto package versions to 0.1.3

### DIFF
--- a/packages/proto-csharp/Macp.Proto.csproj
+++ b/packages/proto-csharp/Macp.Proto.csproj
@@ -7,7 +7,7 @@
 
     <!-- NuGet metadata -->
     <PackageId>Macp.Proto</PackageId>
-    <Version>0.1.0</Version>
+    <Version>0.1.3</Version>
     <Authors>multiagentcoordinationprotocol</Authors>
     <Description>Pre-generated C# protobuf bindings for the Multi-Agent Coordination Protocol (MACP)</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/packages/proto-java/build.gradle.kts
+++ b/packages/proto-java/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.macp"
-version = "0.1.0"
+version = "0.1.3"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/packages/proto-kotlin/build.gradle.kts
+++ b/packages/proto-kotlin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "io.macp"
-version = "0.1.0"
+version = "0.1.3"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    api("io.macp:macp-proto:0.1.0")
+    api("io.macp:macp-proto:0.1.3")
     api("com.google.protobuf:protobuf-kotlin:4.34.1")
     api("io.grpc:grpc-kotlin-stub:1.4.3")
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")

--- a/packages/proto-npm/package.json
+++ b/packages/proto-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiagentcoordinationprotocol/proto",
-  "version": "0.2.0",
+  "version": "0.1.3",
   "description": "MACP protocol buffer definitions — raw .proto files for the Multi-Agent Coordination Protocol",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/packages/proto-python/pyproject.toml
+++ b/packages/proto-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "macp-proto"
-version = "0.1.0"
+version = "0.1.3"
 description = "Pre-generated Python protobuf bindings for the Multi-Agent Coordination Protocol (MACP)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/proto-rust/Cargo.toml
+++ b/packages/proto-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macp-proto"
-version = "0.2.0"
+version = "0.1.3"
 edition = "2021"
 description = "MACP protocol buffer definitions for the Multi-Agent Coordination Protocol"
 license = "Apache-2.0"


### PR DESCRIPTION
The per-language proto package manifests had drifted (Rust/npm at 0.2.0, the rest at 0.1.0) while the published version is 0.1.3. Sets Rust, npm, Python, Java, Kotlin, and C# (and the Kotlin→Java dependency) to **0.1.3** so the repo's canonical version matches what's published. The publish workflow already overrides the version from the tag, so this is a source-of-truth alignment with no behavioral change.