### PR TITLE
conformance: correct canonical fixtures, add linter + CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           chmod +x scripts/validate-json.sh
           ./scripts/validate-json.sh
 
+      - name: Lint conformance fixtures (internal consistency)
+        run: |
+          echo "Linting canonical conformance fixtures..."
+          python3 schemas/conformance/lint_fixtures.py
+
       - name: Install protoc
         run: |
           sudo apt-get update

--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -30,7 +30,7 @@ Each fixture is a JSON object with:
       "expect": "accept"
     }
   ],
-  "expected_final_state": "SESSION_STATE_RESOLVED"
+  "expected_final_state": "Resolved"
 }
 ```
 
@@ -39,30 +39,53 @@ Each fixture is a JSON object with:
 | Field | Used By | Description |
 |-------|---------|-------------|
 | `mode` | Both | Mode identifier |
-| `initiator` | Both | Session initiator |
-| `participants` | Both | Session participants |
+| `initiator` | Both | Session initiator. **Must be a member of `participants`.** |
+| `participants` | Both | Session participants. Must include the initiator and every `accept` sender. |
 | `messages` | Both | Ordered message sequence |
+| `messages[].sender` | Both | Sender identity. For `accept` messages must be a participant; `reject` messages may come from outsiders. |
 | `messages[].expect` | Both | `"accept"` or `"reject"` — whether the runtime accepts the message |
 | `messages[].payload_type` | Both | `"{mode_short}.{MessageType}"` format for payload encoding |
-| `expected_final_state` | Runtime | Expected session state after replay |
-| `expected_mode_state` | Runtime | Mode-specific state assertions (optional) |
+| `messages[].expected_error_code` | Runtime | For `reject` messages, the error code the runtime should return (recommended) |
+| `expected_final_state` | Both | Terminal state: `Open`, `Resolved`, `Suspended`, or `Cancelled`. `Resolved` ⇒ a commitment was emitted. |
+| `expected_resolution` | Both | Commitment field assertions (`action`, `mode_version`, `configuration_version`, `outcome_positive`) when `Resolved` |
+| `expected_mode_state` | Both | Mode-specific assertions: `phase`, `votes` (per proposal/sender), proposal/offer dispositions |
 
-SDKs should only replay messages where `expect == "accept"` through their projections.
+Notes:
+- SDKs replay only `accept` messages through their projections (reject-path
+  fixtures replay their accepted *prefix*).
+- `vote` values are normalized to **uppercase** (`APPROVE` / `REJECT` /
+  `ABSTAIN`); fixtures must use the uppercase form.
+- Proto `bytes` payload fields (e.g. `context`) are written as plain strings and
+  UTF-8 encoded by the harnesses.
+
+## Source of truth & enforcement
+
+This directory is the **single source of truth**. The hierarchy is:
+**RFC prose ▸ runtime behavior ▸ these fixtures ▸ SDK copies.** When a fixture
+disagrees with the RFC or the runtime, the fixture is wrong — fix it here.
+
+Enforcement (all wired into CI, runs on every PR):
+
+- **This repo** lints the fixtures for internal consistency:
+  `python3 schemas/conformance/lint_fixtures.py` (initiator + every `accept`
+  sender must be a participant; schema/expect/final-state validity).
+- **Each SDK** runs `make verify-fixtures`, which fails the build if its vendored
+  copy differs byte-for-byte from this canonical set, plus deepened conformance
+  harnesses that assert transcript, commitment/resolution (incl.
+  `outcome_positive`), `phase`, and `votes`.
 
 ## Syncing Fixtures
 
 Downstream repos sync via Makefile:
 
 ```bash
-make sync-fixtures        # Copy from this directory
-make sync-fixtures-local  # Copy from sibling checkout
+make sync-fixtures     # Copy canonical fixtures into tests/conformance/
+make verify-fixtures   # Fail if the local copy has drifted (CI gate)
 ```
 
-CI in each repo verifies no drift against these canonical fixtures.
+## Adding or Changing Fixtures
 
-## Adding New Fixtures
-
-1. Add the JSON file here in the RFC repo
-2. Ensure it follows the format above
-3. Run `make sync-fixtures` in downstream repos
-4. Verify conformance tests pass in both SDKs and the Runtime
+1. Edit the JSON here in the spec repo (this is the only place fixtures are authored).
+2. `python3 schemas/conformance/lint_fixtures.py` — must pass.
+3. `make sync-fixtures` in **both** SDKs; review `git diff tests/conformance/`.
+4. Conformance tests must pass in **both SDKs and the runtime** before the change is done.

--- a/schemas/conformance/decision_happy_path.json
+++ b/schemas/conformance/decision_happy_path.json
@@ -2,6 +2,7 @@
   "mode": "macp.mode.decision.v1",
   "initiator": "agent://orchestrator",
   "participants": [
+    "agent://orchestrator",
     "agent://a",
     "agent://b"
   ],
@@ -55,7 +56,8 @@
   "expected_resolution": {
     "action": "decision.selected",
     "mode_version": "1.0.0",
-    "configuration_version": "cfg-1"
+    "configuration_version": "cfg-1",
+    "outcome_positive": true
   },
   "expected_mode_state": {
     "phase": "Committed",

--- a/schemas/conformance/decision_reject_paths.json
+++ b/schemas/conformance/decision_reject_paths.json
@@ -2,6 +2,7 @@
   "mode": "macp.mode.decision.v1",
   "initiator": "agent://orchestrator",
   "participants": [
+    "agent://orchestrator",
     "agent://a",
     "agent://b"
   ],

--- a/schemas/conformance/handoff_reject_paths.json
+++ b/schemas/conformance/handoff_reject_paths.json
@@ -54,8 +54,8 @@
         "content_type": "text/plain",
         "context": "late context"
       },
-      "expect": "reject",
-      "expected_error_code": "INVALID_ENVELOPE"
+      "expect": "accept",
+      "_comment": "RFC-MACP-0010 §2.1: late context after accept is permitted as supplementary documentation"
     }
   ],
   "expected_final_state": "Open",

--- a/schemas/conformance/lint_fixtures.py
+++ b/schemas/conformance/lint_fixtures.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Lint the canonical MACP conformance fixtures for internal consistency.
+
+These fixtures are the single source of truth replayed by both SDKs and the
+runtime. A fixture that is internally inconsistent (e.g. an accepted message
+from a non-participant) is silently wrong: SDK projection harnesses don't model
+participant authorization, so the bug only surfaces against the runtime. This
+linter catches that class of defect at the source, before fixtures are synced
+downstream.
+
+Run: `python schemas/conformance/lint_fixtures.py` (exits non-zero on any error).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_TOP_LEVEL = ("mode", "initiator", "participants", "messages", "expected_final_state")
+VALID_EXPECT = {"accept", "reject"}
+VALID_FINAL_STATE = {"Open", "Resolved", "Suspended", "Cancelled"}
+
+
+def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
+    """Return ``(errors, warnings)`` for one fixture. Errors fail the build;
+    warnings are advisory."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"invalid JSON: {exc}"], []
+
+    for key in REQUIRED_TOP_LEVEL:
+        if key not in data:
+            errors.append(f"missing required top-level key '{key}'")
+    if errors:
+        return errors, warnings
+
+    participants = set(data["participants"])
+    initiator = data["initiator"]
+    if initiator not in participants:
+        errors.append(f"initiator {initiator!r} is not in participants")
+
+    final_state = data["expected_final_state"]
+    if final_state not in VALID_FINAL_STATE:
+        errors.append(f"expected_final_state {final_state!r} not in {sorted(VALID_FINAL_STATE)}")
+
+    for i, msg in enumerate(data["messages"]):
+        for key in ("sender", "message_type", "payload_type", "expect"):
+            if key not in msg:
+                errors.append(f"messages[{i}] missing '{key}'")
+        expect = msg.get("expect")
+        if expect not in VALID_EXPECT:
+            errors.append(f"messages[{i}].expect {expect!r} not in {sorted(VALID_EXPECT)}")
+        # An ACCEPTED message must come from a participant; a REJECTED message
+        # may legitimately come from an outsider (that is often why it rejects).
+        if expect == "accept" and msg.get("sender") not in participants:
+            errors.append(
+                f"messages[{i}] accepted message from non-participant {msg.get('sender')!r}"
+            )
+        # Documenting the expected rejection reason is recommended (lets the
+        # runtime assert *why* a message rejected) but not yet universal.
+        if expect == "reject" and "expected_error_code" not in msg:
+            warnings.append(f"messages[{i}] reject message has no 'expected_error_code'")
+
+    return errors, warnings
+
+
+def main() -> int:
+    fixtures_dir = Path(__file__).parent
+    fixtures = sorted(fixtures_dir.glob("*.json"))
+    if not fixtures:
+        print(f"No fixtures found in {fixtures_dir}", file=sys.stderr)
+        return 1
+
+    failed = False
+    warned = False
+    for path in fixtures:
+        errors, warnings = lint_fixture(path)
+        if errors:
+            failed = True
+            print(f"FAIL {path.name}")
+            for err in errors:
+                print(f"  - error:   {err}")
+        elif warnings:
+            warned = True
+            print(f"warn {path.name}")
+        else:
+            print(f"ok   {path.name}")
+        for warn in warnings:
+            print(f"  - warning: {warn}")
+
+    if failed:
+        print("\nConformance fixtures have consistency errors (see above).", file=sys.stderr)
+        return 1
+    suffix = " (with advisory warnings)" if warned else ""
+    print(f"\nAll {len(fixtures)} conformance fixtures are internally consistent{suffix}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/schemas/conformance/multi_round_happy_path.json
+++ b/schemas/conformance/multi_round_happy_path.json
@@ -1,7 +1,11 @@
 {
   "mode": "ext.multi_round.v1",
   "initiator": "agent://coordinator",
-  "participants": ["agent://alice", "agent://bob"],
+  "participants": [
+    "agent://coordinator",
+    "agent://alice",
+    "agent://bob"
+  ],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -11,21 +15,27 @@
       "sender": "agent://alice",
       "message_type": "Contribute",
       "payload_type": "multi_round.Contribute",
-      "payload": { "value": "option_a" },
+      "payload": {
+        "value": "option_a"
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
       "payload_type": "multi_round.Contribute",
-      "payload": { "value": "option_b" },
+      "payload": {
+        "value": "option_b"
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
       "payload_type": "multi_round.Contribute",
-      "payload": { "value": "option_a" },
+      "payload": {
+        "value": "option_a"
+      },
       "expect": "accept"
     },
     {

--- a/schemas/conformance/multi_round_reject_paths.json
+++ b/schemas/conformance/multi_round_reject_paths.json
@@ -1,7 +1,11 @@
 {
   "mode": "ext.multi_round.v1",
   "initiator": "agent://coordinator",
-  "participants": ["agent://alice", "agent://bob"],
+  "participants": [
+    "agent://coordinator",
+    "agent://alice",
+    "agent://bob"
+  ],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -27,14 +31,18 @@
       "sender": "agent://alice",
       "message_type": "Contribute",
       "payload_type": "multi_round.Contribute",
-      "payload": { "value": "option_a" },
+      "payload": {
+        "value": "option_a"
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
       "payload_type": "multi_round.Contribute",
-      "payload": { "value": "option_a" },
+      "payload": {
+        "value": "option_a"
+      },
       "expect": "accept"
     },
     {

--- a/schemas/conformance/proposal_happy_path.json
+++ b/schemas/conformance/proposal_happy_path.json
@@ -65,7 +65,8 @@
   "expected_resolution": {
     "action": "proposal.accepted",
     "mode_version": "1.0.0",
-    "configuration_version": "cfg-1"
+    "configuration_version": "cfg-1",
+    "outcome_positive": true
   },
   "expected_mode_state": {
     "phase": "Committed",

--- a/schemas/conformance/quorum_happy_path.json
+++ b/schemas/conformance/quorum_happy_path.json
@@ -1,7 +1,12 @@
 {
   "mode": "macp.mode.quorum.v1",
   "initiator": "agent://coordinator",
-  "participants": ["agent://alice", "agent://bob", "agent://carol"],
+  "participants": [
+    "agent://coordinator",
+    "agent://alice",
+    "agent://bob",
+    "agent://carol"
+  ],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -11,21 +16,33 @@
       "sender": "agent://coordinator",
       "message_type": "ApprovalRequest",
       "payload_type": "quorum.ApprovalRequest",
-      "payload": { "request_id": "r1", "action": "deploy", "summary": "Deploy v2", "details": [], "required_approvals": 2 },
+      "payload": {
+        "request_id": "r1",
+        "action": "deploy",
+        "summary": "Deploy v2",
+        "details": [],
+        "required_approvals": 2
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://alice",
       "message_type": "Approve",
       "payload_type": "quorum.Approve",
-      "payload": { "request_id": "r1", "reason": "lgtm" },
+      "payload": {
+        "request_id": "r1",
+        "reason": "lgtm"
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Approve",
       "payload_type": "quorum.Approve",
-      "payload": { "request_id": "r1", "reason": "ship it" },
+      "payload": {
+        "request_id": "r1",
+        "reason": "ship it"
+      },
       "expect": "accept"
     },
     {

--- a/schemas/conformance/quorum_reject_paths.json
+++ b/schemas/conformance/quorum_reject_paths.json
@@ -1,7 +1,12 @@
 {
   "mode": "macp.mode.quorum.v1",
   "initiator": "agent://coordinator",
-  "participants": ["agent://alice", "agent://bob", "agent://carol"],
+  "participants": [
+    "agent://coordinator",
+    "agent://alice",
+    "agent://bob",
+    "agent://carol"
+  ],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -11,21 +16,32 @@
       "sender": "agent://alice",
       "message_type": "Approve",
       "payload_type": "quorum.Approve",
-      "payload": { "request_id": "r1", "reason": "lgtm" },
+      "payload": {
+        "request_id": "r1",
+        "reason": "lgtm"
+      },
       "expect": "reject"
     },
     {
       "sender": "agent://coordinator",
       "message_type": "ApprovalRequest",
       "payload_type": "quorum.ApprovalRequest",
-      "payload": { "request_id": "r1", "action": "deploy", "summary": "Deploy v2", "required_approvals": 2 },
+      "payload": {
+        "request_id": "r1",
+        "action": "deploy",
+        "summary": "Deploy v2",
+        "required_approvals": 2
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://alice",
       "message_type": "Approve",
       "payload_type": "quorum.Approve",
-      "payload": { "request_id": "r1", "reason": "lgtm" },
+      "payload": {
+        "request_id": "r1",
+        "reason": "lgtm"
+      },
       "expect": "accept"
     },
     {


### PR DESCRIPTION
Reconcile the canonical conformance fixtures (the single source of truth for both SDKs and the runtime) against the RFC and fix internal inconsistencies:

- handoff_reject_paths: late HandoffContext after accept is now `accept`, per RFC-MACP-0010 §2.1 (late context is permitted as supplementary documentation). The fixture previously expected INVALID_ENVELOPE, contradicting the RFC.
- decision/multi_round/quorum fixtures: add the initiator to `participants` (it sent accepted messages but was missing from the participant set — the runtime would reject such messages).
- decision_happy / proposal_happy: assert `outcome_positive` in expected_resolution.

Add schemas/conformance/lint_fixtures.py (initiator + every accept-sender must be a participant; schema/expect/final-state validity) and wire it into CI. Update the README: source-of-truth hierarchy, enforcement (lint + per-SDK verify-fixtures), vote casing, bytes encoding, and the corrected example.


## Summary

Describe the changes introduced by this pull request.

## Type of Change

- [ ] RFC update
- [ ] New RFC
- [ ] Schema change (proto/json)
- [ ] Documentation improvement
- [ ] Example update
- [ ] CI / tooling change

## Checklist

- [ ] I have updated the relevant RFC section (if applicable)
- [ ] I have updated schemas (if applicable)
- [ ] JSON examples validate against the schema
- [ ] Protobuf definitions compile successfully
- [ ] This change preserves MACP Core invariants
