### PR TITLE
Canonicalize Decision Mode negative committed outcomes (schema_version 2)

### DIFF
--- a/docs/policy.md
+++ b/docs/policy.md
@@ -30,7 +30,7 @@ A policy descriptor has five required fields:
 | `mode` | string | Target mode identifier or `*` for mode-agnostic |
 | `description` | string | Human-readable description |
 | `rules` | object | Mode-specific governance rules (see Rule Schemas) |
-| `schema_version` | uint32 | Version of the rule schema used (currently `1`) |
+| `schema_version` | uint32 | Version of the rule schema used (`1` or `2`; version `2` adds Decision Mode decline-gating, additive) |
 
 Canonical proto: [`schemas/proto/macp/v1/policy.proto`](../schemas/proto/macp/v1/policy.proto)
 JSON Schema: [`schemas/json/macp-policy-descriptor.schema.json`](../schemas/json/macp-policy-descriptor.schema.json)

--- a/examples/discovery/policy_descriptor_decline.json
+++ b/examples/discovery/policy_descriptor_decline.json
@@ -1,0 +1,21 @@
+{
+  "policy_id": "policy.platform.majority-decline",
+  "mode": "macp.mode.decision.v1",
+  "description": "Majority voting that permits a vote-gated negative (decline) outcome and finalizes a decline on critical objection (schema_version 2).",
+  "schema_version": 2,
+  "rules": {
+    "voting": {
+      "algorithm": "majority"
+    },
+    "objection_handling": {
+      "critical_severity_vetoes": true,
+      "veto_threshold": 1,
+      "critical_objection_action": "finalize_decline"
+    },
+    "commitment": {
+      "authority": "initiator_only",
+      "require_vote_quorum": true,
+      "allow_decline_over_approval": false
+    }
+  }
+}

--- a/rfcs/RFC-MACP-0007-decision-mode.md
+++ b/rfcs/RFC-MACP-0007-decision-mode.md
@@ -99,6 +99,20 @@ Decision Mode allows both positive and negative committed outcomes. `CommitmentP
 
 Decision sessions MAY be governed by declarative policies that constrain voting algorithms, quorum requirements, objection handling, and commitment authority. See [RFC-MACP-0012](RFC-MACP-0012-policy.md) for the governance policy framework and `schemas/json/policy/decision-rules.schema.json` for the Decision Mode rule schema.
 
+### 6.2 Negative committed outcomes (vote-gated decline)
+
+When a Decision session binds a governance policy with a real voting algorithm (`voting.algorithm != "none"`), the eligibility of a positive versus negative `Commitment` is gated by the computed voting result:
+
+- **Passed** — a positive commitment (`outcome_positive: true`) is allowed; a negative commitment is denied **unless** `commitment.allow_decline_over_approval` is `true`.
+- **Failed** — a positive commitment is denied; a negative commitment is allowed **iff** the decline guard (below) is satisfied.
+- **NoVotes** — a negative commitment is denied; there is no explicit reject to authorize a decline.
+
+**Decline guard (normative):** a vote-authorized negative commitment MUST be backed by at least one explicit `Vote` with `vote == "REJECT"` (`reject_count > 0`), and, when `commitment.require_vote_quorum` is `true`, the voting quorum MUST be met. The guard applies across all three voting results.
+
+**Face-value exception:** when `voting.algorithm == "none"` (or no policy is bound), the commitment is initiator-driven and `outcome_positive` is taken at face value with no decline guard.
+
+Both governing knobs — `commitment.allow_decline_over_approval` (bool, default `false`) and `objection_handling.critical_objection_action` (enum `deny` | `finalize_decline` | `hold`, default `deny`) — are policy-controlled with conservative defaults that preserve pre-existing behavior. See [RFC-MACP-0012](RFC-MACP-0012-policy.md) §4.1 for their semantics.
+
 ## 7. Determinism class
 
 Decision Mode claims **semantic-deterministic** determinism.

--- a/rfcs/RFC-MACP-0012-policy.md
+++ b/rfcs/RFC-MACP-0012-policy.md
@@ -59,7 +59,9 @@ A policy descriptor is a structured document with the following required fields:
 | `mode` | string | Target mode identifier (e.g., `macp.mode.decision.v1`) or `*` for mode-agnostic |
 | `description` | string | Human-readable description of the policy's governance rules |
 | `rules` | object | Mode-specific governance rules (see Section 4) |
-| `schema_version` | uint32 | Version of the rule schema used (currently `1`) |
+| `schema_version` | uint32 | Version of the rule schema used (`1` or `2`) |
+
+Schema version `2` adds the Decision Mode decline-gating parameters (`commitment.allow_decline_over_approval`, `objection_handling.critical_objection_action`; see §4.1). The bump is **additive**: the new fields are optional and default to legacy behavior, so `schema_version: 1` policies remain valid and a runtime MUST accept every schema version it supports (`{1, 2}`). Declaring `schema_version: 2` signals only that the descriptor MAY use the new fields.
 
 The canonical wire format is defined in `schemas/proto/macp/v1/policy.proto`. The `rules` field is JSON-encoded bytes to allow mode-specific schemas without requiring proto changes per mode.
 
@@ -76,9 +78,9 @@ Canonical schema: `schemas/json/policy/decision-rules.schema.json`
 | Rule Group | Parameters | Description |
 |------------|-----------|-------------|
 | `voting` | `algorithm`, `threshold`, `quorum`, `weights` | Voting algorithm and quorum requirements |
-| `objection_handling` | `critical_severity_vetoes`, `veto_threshold` | How critical-severity objections affect commitment eligibility |
+| `objection_handling` | `critical_severity_vetoes`, `veto_threshold`, `critical_objection_action` | How critical-severity objections affect commitment eligibility |
 | `evaluation` | `minimum_confidence`, `required_before_voting` | Evaluation constraints |
-| `commitment` | `authority`, `designated_roles`, `require_vote_quorum` | Who can commit and under what conditions |
+| `commitment` | `authority`, `designated_roles`, `require_vote_quorum`, `allow_decline_over_approval` | Who can commit and under what conditions |
 
 **Voting algorithms:**
 
@@ -93,6 +95,13 @@ Canonical schema: `schemas/json/policy/decision-rules.schema.json`
 
 - `type: "count"` — minimum number of votes that must be cast
 - `type: "percentage"` — minimum percentage of declared participants that must vote
+
+**Negative-outcome parameters:**
+
+- `commitment.allow_decline_over_approval` (bool, default `false`) — permit a negative commitment (`outcome_positive: false`) even when the vote **Passed**. With the default `false`, a passed vote authorizes only a positive commitment.
+- `objection_handling.critical_objection_action` (enum `deny` | `finalize_decline` | `hold`, default `deny`) — action taken when a critical objection would block commitment: `deny` (reject the commitment; legacy behavior), `finalize_decline` (finalize the session as a negative outcome), or `hold` (leave the session open).
+
+The **decline guard** for a vote-authorized negative commitment (≥1 explicit `Vote` with `vote == "REJECT"`; optional `commitment.require_vote_quorum`) is defined with the Decision Mode terminal semantics — see [RFC-MACP-0007](RFC-MACP-0007-decision-mode.md) §6.2. Both parameters are additive with conservative defaults that preserve pre-existing behavior; policies that use them declare `schema_version: 2`.
 
 ### 4.2 Quorum Mode Rules
 

--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -45,6 +45,7 @@ Each fixture is a JSON object with:
 | `messages[].sender` | Both | Sender identity. For `accept` messages must be a participant; `reject` messages may come from outsiders. |
 | `messages[].expect` | Both | `"accept"` or `"reject"` — whether the runtime accepts the message |
 | `messages[].payload_type` | Both | `"{mode_short}.{MessageType}"` format for payload encoding |
+| `policy` | Runtime | Optional inline `PolicyDescriptor` (`policy_id`, `mode`, `schema_version`, `rules`) the harness registers before `SessionStart`, so a bound (non-`none`) voting algorithm is reachable. `policy_version` must match its `policy_id`. Absent ⇒ default policy. |
 | `messages[].expected_error_code` | Runtime | For `reject` messages, the error code the runtime should return (recommended) |
 | `expected_final_state` | Both | Terminal state: `Open`, `Resolved`, `Suspended`, or `Cancelled`. `Resolved` ⇒ a commitment was emitted. |
 | `expected_resolution` | Both | Commitment field assertions (`action`, `mode_version`, `configuration_version`, `outcome_positive`) when `Resolved` |

--- a/schemas/conformance/decision_negative_outcome.json
+++ b/schemas/conformance/decision_negative_outcome.json
@@ -1,0 +1,119 @@
+{
+  "mode": "macp.mode.decision.v1",
+  "initiator": "agent://orchestrator",
+  "participants": [
+    "agent://orchestrator",
+    "agent://a",
+    "agent://b"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy": {
+    "policy_id": "policy.decision.majority-decline",
+    "mode": "macp.mode.decision.v1",
+    "schema_version": 2,
+    "description": "Majority vote, initiator-only commitment; permits a vote-gated negative (decline) outcome.",
+    "rules": {
+      "voting": { "algorithm": "majority" },
+      "commitment": { "authority": "initiator_only" }
+    }
+  },
+  "policy_version": "policy.decision.majority-decline",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://orchestrator",
+      "message_type": "Proposal",
+      "payload_type": "decision.Proposal",
+      "payload": {
+        "proposal_id": "p1",
+        "option": "deploy",
+        "rationale": "ready",
+        "supporting_data": []
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://orchestrator",
+      "message_type": "Commitment",
+      "payload_type": "Commitment",
+      "payload": {
+        "commitment_id": "c0",
+        "outcome_positive": false,
+        "action": "decision.selected",
+        "authority_scope": "test",
+        "reason": "premature decline with no explicit reject cast yet",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.decision.majority-decline",
+        "configuration_version": "cfg-1"
+      },
+      "expect": "reject",
+      "expected_error_code": "POLICY_DENIED"
+    },
+    {
+      "sender": "agent://a",
+      "message_type": "Vote",
+      "payload_type": "decision.Vote",
+      "payload": {
+        "proposal_id": "p1",
+        "vote": "REJECT",
+        "reason": "not ready"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://b",
+      "message_type": "Vote",
+      "payload_type": "decision.Vote",
+      "payload": {
+        "proposal_id": "p1",
+        "vote": "REJECT",
+        "reason": "regression risk"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://orchestrator",
+      "message_type": "Commitment",
+      "payload_type": "Commitment",
+      "payload": {
+        "commitment_id": "c1",
+        "outcome_positive": false,
+        "action": "decision.selected",
+        "authority_scope": "test",
+        "reason": "reject-majority under bound policy",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.decision.majority-decline",
+        "configuration_version": "cfg-1"
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "decision.selected",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  },
+  "expected_mode_state": {
+    "phase": "Committed",
+    "proposals": {
+      "p1": {
+        "proposal_id": "p1",
+        "sender": "agent://orchestrator"
+      }
+    },
+    "votes": {
+      "p1": {
+        "agent://a": {
+          "vote": "REJECT"
+        },
+        "agent://b": {
+          "vote": "REJECT"
+        }
+      }
+    }
+  }
+}

--- a/schemas/conformance/lint_fixtures.py
+++ b/schemas/conformance/lint_fixtures.py
@@ -20,6 +20,9 @@ from pathlib import Path
 REQUIRED_TOP_LEVEL = ("mode", "initiator", "participants", "messages", "expected_final_state")
 VALID_EXPECT = {"accept", "reject"}
 VALID_FINAL_STATE = {"Open", "Resolved", "Suspended", "Cancelled"}
+# Schema versions a conformant runtime is expected to accept for an inline policy
+# (RFC-MACP-0012 §3). Additive: 1 is legacy, 2 adds Decision decline-gating.
+VALID_POLICY_SCHEMA_VERSIONS = {1, 2}
 
 
 def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
@@ -46,6 +49,35 @@ def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
     final_state = data["expected_final_state"]
     if final_state not in VALID_FINAL_STATE:
         errors.append(f"expected_final_state {final_state!r} not in {sorted(VALID_FINAL_STATE)}")
+
+    # Optional inline policy: a fixture MAY carry a policy descriptor the harness
+    # registers before SessionStart so a bound (non-'none') voting algorithm is
+    # reachable. Validated only when present; fixtures without it stay valid.
+    policy = data.get("policy")
+    if policy is not None:
+        if not isinstance(policy, dict):
+            errors.append("'policy' must be an object")
+        else:
+            for key in ("policy_id", "mode", "schema_version", "rules"):
+                if key not in policy:
+                    errors.append(f"policy missing required key '{key}'")
+            sv = policy.get("schema_version")
+            if sv is not None and sv not in VALID_POLICY_SCHEMA_VERSIONS:
+                errors.append(
+                    f"policy.schema_version {sv!r} not in {sorted(VALID_POLICY_SCHEMA_VERSIONS)}"
+                )
+            if isinstance(policy.get("rules"), dict) is False and "rules" in policy:
+                errors.append("policy.rules must be an object")
+            if policy.get("mode") not in (None, "*", data["mode"]):
+                errors.append(
+                    f"policy.mode {policy.get('mode')!r} matches neither '*' nor fixture mode {data['mode']!r}"
+                )
+            # An inline policy should be the one the session binds.
+            pid = policy.get("policy_id")
+            if pid is not None and data.get("policy_version") not in (None, pid):
+                errors.append(
+                    f"policy_version {data.get('policy_version')!r} does not match inline policy_id {pid!r}"
+                )
 
     for i, msg in enumerate(data["messages"]):
         for key in ("sender", "message_type", "payload_type", "expect"):

--- a/schemas/json/macp-policy-descriptor.schema.json
+++ b/schemas/json/macp-policy-descriptor.schema.json
@@ -17,7 +17,7 @@
     "schema_version": {
       "type": "integer",
       "minimum": 1,
-      "description": "Version of the rule schema used (currently 1)."
+      "description": "Version of the rule schema used (1 or 2). Version 2 adds the Decision Mode decline-gating parameters; the bump is additive and version 1 policies remain valid."
     },
     "rules": {
       "type": "object",

--- a/schemas/json/policy/decision-rules.schema.json
+++ b/schemas/json/policy/decision-rules.schema.json
@@ -63,6 +63,12 @@
           "minimum": 1,
           "default": 1,
           "description": "Number of blocking objections required to veto commitment."
+        },
+        "critical_objection_action": {
+          "type": "string",
+          "enum": ["deny", "finalize_decline", "hold"],
+          "default": "deny",
+          "description": "Action when a critical objection would block commitment: deny (reject), finalize_decline (resolve as a negative outcome), or hold (leave the session open)."
         }
       }
     },
@@ -103,6 +109,11 @@
           "type": "boolean",
           "default": false,
           "description": "If true, commitment is only allowed after vote quorum is met."
+        },
+        "allow_decline_over_approval": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, a negative commitment (outcome_positive=false) is allowed even when the vote passed."
         }
       }
     }


### PR DESCRIPTION
## Summary

Canonicalizes, in the normative spec, the vote-gated **decline** behavior the runtime already ships: a Decision Mode session may finalize on a **negative** commitment (`CommitmentPayload.outcome_positive = false`) instead of being forced to cancel when the vote fails. Introduces policy `schema_version: 2` as an **additive** bump.

Implements the plan in `plans/decision-negative-committed-outcomes.md` (Steps 1–4; Step 5 is cross-repo).

## Changes

- **RFC-MACP-0007 §6.2** — new *Negative committed outcomes (vote-gated decline)* subsection: Passed/Failed/NoVotes → commitment eligibility, the normative **decline guard** (≥1 explicit `REJECT`; optional quorum), and the `algorithm == "none"` face-value exception. §7 determinism claim unaffected (pure function of votes + rules).
- **RFC-MACP-0012** — §4.1 documents `objection_handling.critical_objection_action` and `commitment.allow_decline_over_approval`; §3 reframes `schema_version` as additive `{1, 2}`. Default policy stays `schema_version: 1`.
- **Schemas** — `decision-rules.schema.json` gains the two optional fields (no `additionalProperties`, so old/new producers stay compatible); `macp-policy-descriptor.schema.json` + `docs/policy.md` updated to `1` or `2`.
- **Conformance** — new `decision_negative_outcome.json` vector carrying an **inline `policy`** (majority algorithm) plus a guard case (premature decline before any reject → `POLICY_DENIED`). `lint_fixtures.py` now validates the optional inline policy block (advisory-compatible); README documents the new field.
- **Example** — `examples/discovery/policy_descriptor_decline.json`: a `schema_version: 2` descriptor exercising both new fields.

## Validation

- `python3 schemas/conformance/lint_fixtures.py` — passes (all 13 fixtures consistent).
- v2 descriptor + v2 rules validate against their JSON schemas; bad enum values rejected.

## Coordinated follow-ups (separate repos, tracked as plans)

- **`macp-runtime`** — widen `SUPPORTED_SCHEMA_VERSION` to `{1, 2}` and teach the conformance loader to register the fixture's inline policy. Until this lands, the runtime conformance job is red on the new vector (unknown policy version). Plan: `macp-runtime/plans/decision-negative-outcome-schema-v2.md`.
- **`macp-sdk-python` / `macp-sdk-typescript`** — `make sync-fixtures` + `verify-fixtures` (no projection code change expected). Plans in each repo's `plans/`.

> Note: **do not deploy v2 policies before the `macp-runtime` follow-up merges**, or the runtime rejects every v2 descriptor.