### PR TITLE
fix(conformance): use a negative action suffix in decision_negative_outcome

### DIFF
--- a/schemas/conformance/decision_negative_outcome.json
+++ b/schemas/conformance/decision_negative_outcome.json
@@ -40,7 +40,7 @@
       "payload": {
         "commitment_id": "c0",
         "outcome_positive": false,
-        "action": "decision.selected",
+        "action": "decision.rejected",
         "authority_scope": "test",
         "reason": "premature decline with no explicit reject cast yet",
         "mode_version": "1.0.0",
@@ -79,7 +79,7 @@
       "payload": {
         "commitment_id": "c1",
         "outcome_positive": false,
-        "action": "decision.selected",
+        "action": "decision.rejected",
         "authority_scope": "test",
         "reason": "reject-majority under bound policy",
         "mode_version": "1.0.0",
@@ -92,7 +92,7 @@
   "expected_final_state": "Resolved",
   "expect_resolution_present": true,
   "expected_resolution": {
-    "action": "decision.selected",
+    "action": "decision.rejected",
     "mode_version": "1.0.0",
     "configuration_version": "cfg-1",
     "outcome_positive": false


### PR DESCRIPTION
## Summary

The canonical `decision_negative_outcome.json` vector pairs action `decision.selected` with `outcome_positive: false` on **both** `Commitment` messages. Runtimes that enforce action/outcome consistency treat a `…selected` suffix as **positive** (requiring `outcome_positive: true`) and reject the commitment as an invalid envelope **before** policy evaluation.

Effect against the reference runtime (`macp-runtime`):
- the premature-decline case surfaces an `INVALID_ENVELOPE` error instead of the asserted `POLICY_DENIED`;
- the final decline is rejected rather than resolving, so `expected_final_state: "Resolved"` never holds.

## Fix

Use `decision.rejected` (a negative-suffix action) for both `Commitment` messages and update `expected_resolution.action` to match. Semantics are unchanged — a reject-majority decline — but the action now agrees with `outcome_positive: false`.

## Validation

- Passes the reference runtime's conformance loader end-to-end (premature decline → `POLICY_DENIED`; two `REJECT` votes accepted; final decline → `Resolved`, `outcome_positive: false`).
- `schemas/conformance/lint_fixtures.py` reports `ok decision_negative_outcome.json`.

3-line change; no schema or RFC prose changes.
