### PR TITLE
fix(policy): specify the resolved policy_version echo contract

### DIFF
--- a/rfcs/RFC-MACP-0012-policy.md
+++ b/rfcs/RFC-MACP-0012-policy.md
@@ -179,6 +179,9 @@ At `SessionStart`:
 4. If the policy is not found, the runtime MUST reject the `SessionStart` with error code `UNKNOWN_POLICY_VERSION`.
 5. If the policy's `mode` field is not `*` and does not match the session's mode, the runtime MUST reject with `INVALID_POLICY_DEFINITION`.
 6. The resolved `PolicyDescriptor` (including the full `rules` object) is stored on the session for the session's lifetime.
+7. The session's persisted metadata MUST record the **resolved** policy identifier — `policy.default` when the payload was empty — not the raw payload value. Replay equality (Section 8) and any observer surface (`GetSession`, lifecycle events) refer to the resolved identifier.
+
+**Commitment echo.** `CommitmentPayload.policy_version` binds the commitment to the session's governance policy. An **empty** `policy_version` in the commitment matches the session's bound policy (whatever it resolved to) — a client that started with an empty `policy_version` is not required to echo a value it never sent. A **non-empty** `policy_version` MUST equal the session's resolved policy identifier exactly; otherwise the runtime MUST reject the commitment as invalid. Runtimes MUST NOT require clients to echo `policy.default` literally.
 
 ### 6.2 Commitment Evaluation
 


### PR DESCRIPTION
Closes #36 (freeze-blocking).

## Problem
RFC-0012 §6.1 defines empty-`policy_version` resolution to `policy.default` but never says (a) whether persisted session metadata records the rewritten value (replay-equality relevant per §8) or (b) what `CommitmentPayload.policy_version` must carry when the session started with empty. macp-runtime originally required the Commitment to echo `policy.default` — rejecting clients for not echoing a value they never sent.

## Change (RFC-0012 §6.1)
- New resolution step 7: persisted session metadata MUST record the **resolved** identifier (`policy.default` when started empty); replay equality and observer surfaces refer to it.
- New **Commitment echo** paragraph: empty `commitment.policy_version` matches the session's bound policy; non-empty MUST equal the resolved identifier exactly; runtimes MUST NOT require clients to echo `policy.default` literally.

## Compatibility
This blesses the permissive reading macp-runtime already ships (A3 in its A–E change set), which is forward-compatible from both directions: clients that echo still pass, clients that send empty now conformantly pass. No proto changes.