### PR TITLE
fix(policy): quorum threshold schema — percentage typing + threshold-is-only-gate ruling

### DIFF
--- a/rfcs/RFC-MACP-0012-policy.md
+++ b/rfcs/RFC-MACP-0012-policy.md
@@ -113,6 +113,8 @@ Canonical schema: `schemas/json/policy/quorum-rules.schema.json`
 | `abstention` | `counts_toward_quorum`, `interpretation` | How abstentions affect quorum calculation |
 | `commitment` | `authority` | Who can emit the terminal `Commitment` |
 
+`threshold` is the **approval bar** — the number (or percentage/weighted sum) of approvals required for a positive outcome — and it is the **only gate** defined in schema_version ≤ 2. There is no separate *participation quorum* (a minimum number of ballots cast regardless of direction); implementations MUST NOT reinterpret `threshold` as one. If a participation quorum is desired, it requires a distinct rule field in a future schema version. The `percentage` threshold type is an **integer percentage (0–100)** of eligible participants.
+
 ### 4.3 Proposal Mode Rules
 
 Canonical schema: `schemas/json/policy/proposal-rules.schema.json`

--- a/schemas/json/policy/quorum-rules.schema.json
+++ b/schemas/json/policy/quorum-rules.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "threshold": {
       "type": "object",
-      "description": "Override the required_approvals from ApprovalRequest. Type 'n_of_m' uses a raw count, 'percentage' uses a fraction (0-1) of eligible participants, 'weighted' uses a weighted sum of participant weights.",
+      "description": "Override the required_approvals from ApprovalRequest (RFC-MACP-0012 Section 4.2). This is the approval bar and the ONLY gate in schema_version <= 2 — there is no separate participation quorum. Type 'n_of_m' uses a raw approval count, 'percentage' uses an integer percentage (0-100) of eligible participants, 'weighted' uses a weighted sum of participant weights.",
       "properties": {
         "type": {
           "type": "string",
@@ -17,9 +17,20 @@
         "value": {
           "type": "integer",
           "minimum": 0,
-          "description": "Threshold value: count for n_of_m, fraction (0-1) for percentage, weighted sum for weighted."
+          "description": "Threshold value: approval count for n_of_m, integer percentage 0-100 for percentage, weighted sum for weighted."
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "type": { "const": "percentage" } },
+            "required": ["type"]
+          },
+          "then": {
+            "properties": { "value": { "maximum": 100 } }
+          }
+        }
+      ]
     },
     "abstention": {
       "type": "object",


### PR DESCRIPTION
Closes #37.

## (a) `percentage` typing defect
`threshold.value` was `integer` with description "fraction (0-1)" — an integer fraction expresses only 0% or 100%. Implementations (including macp-runtime, `quorum.rs`) already treat it as a **0–100 integer percentage**. Decision taken: keep `integer`, make the 0–100 percentage semantics explicit (this matches every implementation, so nothing breaks), and add an `if/then` bound (`value ≤ 100` when `type = "percentage"`).

## (b) Participation-quorum ambiguity
RFC-0012 §4.2 now states normatively: `threshold` is the **approval bar** and the **only gate** in schema_version ≤ 2; there is no separate participation quorum and implementations MUST NOT reinterpret `threshold` as one (macp-runtime's evaluator had — RFC-0012 §4.2's "overrides the required_approvals" adjudicated it, and that reading was removed in its A–E change set). A participation quorum, if desired, gets its own rule field in a future schema version.

## Note for reviewers
`abstention.counts_toward_quorum`'s schema description still says "counts toward the participation quorum" — which now names a concept this ruling says doesn't exist in ≤ v2. I deliberately left that field untouched (changing its meaning is a semantic decision beyond this fix); it should probably be clarified or deprecated alongside any future participation-quorum field.

Verified: JSON schema meta-validation + example validation green.