### PR TITLE
feat(conformance): canonical fixture pack — runtime-verified fixtures, schema, mode-aware linter

### DIFF
--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -9,6 +9,24 @@ These JSON fixtures define message sequences for each coordination mode. They ar
 - **Runtime** — validates session state machine transitions and commitment logic
 - **SDKs** — validates projection state tracking (transcript, phase, commitment fields)
 
+## Single canonical source
+
+This directory is the **only** canonical fixture location. `macp-runtime`
+vendors byte-identical copies under `tests/conformance/` for hermetic local
+runs, and its CI oracle job (a) byte-compares the vendored copies against this
+directory and (b) re-runs its conformance suite directly against these files —
+so the spec and the runtime cannot drift silently. Fixture changes land HERE
+first, then sync downstream.
+
+`schema.json` is the JSON Schema (draft 2020-12) for the fixture format —
+payload-type names are fully-qualified proto names
+(`macp.modes.decision.v1.ProposalPayload`, `macp.v1.CommitmentPayload`).
+Reject messages should carry `expected_error_code` (asserted by the runtime
+harness). `lint_fixtures.py` checks internal consistency; note that initiator
+participant-list membership is mode-specific (only handoff's delegated model
+requires it — RFC-0010 §2; quorum's coordinator is explicitly OUTSIDE the
+voter pool per RFC-0011 §2).
+
 ## Fixture Format
 
 Each fixture is a JSON object with:

--- a/schemas/conformance/decision_happy_path.json
+++ b/schemas/conformance/decision_happy_path.json
@@ -14,7 +14,7 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Proposal",
-      "payload_type": "decision.Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
       "payload": {
         "proposal_id": "p1",
         "option": "deploy",
@@ -26,7 +26,7 @@
     {
       "sender": "agent://a",
       "message_type": "Vote",
-      "payload_type": "decision.Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
       "payload": {
         "proposal_id": "p1",
         "vote": "APPROVE",
@@ -37,16 +37,16 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "decision.selected",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/decision_negative_outcome.json
+++ b/schemas/conformance/decision_negative_outcome.json
@@ -24,7 +24,7 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Proposal",
-      "payload_type": "decision.Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
       "payload": {
         "proposal_id": "p1",
         "option": "deploy",
@@ -36,7 +36,7 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c0",
         "outcome_positive": false,
@@ -53,7 +53,7 @@
     {
       "sender": "agent://a",
       "message_type": "Vote",
-      "payload_type": "decision.Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
       "payload": {
         "proposal_id": "p1",
         "vote": "REJECT",
@@ -64,7 +64,7 @@
     {
       "sender": "agent://b",
       "message_type": "Vote",
-      "payload_type": "decision.Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
       "payload": {
         "proposal_id": "p1",
         "vote": "REJECT",
@@ -75,7 +75,7 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
         "outcome_positive": false,

--- a/schemas/conformance/decision_reject_paths.json
+++ b/schemas/conformance/decision_reject_paths.json
@@ -14,7 +14,7 @@
     {
       "sender": "agent://outsider",
       "message_type": "Proposal",
-      "payload_type": "decision.Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
       "payload": {
         "proposal_id": "p1",
         "option": "deploy",
@@ -27,7 +27,7 @@
     {
       "sender": "agent://orchestrator",
       "message_type": "Proposal",
-      "payload_type": "decision.Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
       "payload": {
         "proposal_id": "p1",
         "option": "deploy",
@@ -39,16 +39,16 @@
     {
       "sender": "agent://a",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "decision.selected",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "reject",
       "expected_error_code": "FORBIDDEN"
@@ -56,7 +56,7 @@
     {
       "sender": "agent://a",
       "message_type": "Vote",
-      "payload_type": "decision.Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
       "payload": {
         "proposal_id": "p1",
         "vote": "APPROVE",
@@ -67,10 +67,10 @@
     {
       "sender": "agent://b",
       "message_type": "Evaluation",
-      "payload_type": "decision.Evaluation",
+      "payload_type": "macp.modes.decision.v1.EvaluationPayload",
       "payload": {
         "proposal_id": "p1",
-        "recommendation": "approve",
+        "recommendation": "APPROVE",
         "confidence": 0.7,
         "reason": "late"
       },

--- a/schemas/conformance/handoff_happy_path.json
+++ b/schemas/conformance/handoff_happy_path.json
@@ -10,30 +10,30 @@
     {
       "sender": "agent://owner",
       "message_type": "HandoffOffer",
-      "payload_type": "handoff.HandoffOffer",
+      "payload_type": "macp.modes.handoff.v1.HandoffOfferPayload",
       "payload": { "handoff_id": "h1", "target_participant": "agent://target", "scope": "support", "reason": "escalate" },
       "expect": "accept"
     },
     {
       "sender": "agent://target",
       "message_type": "HandoffAccept",
-      "payload_type": "handoff.HandoffAccept",
+      "payload_type": "macp.modes.handoff.v1.HandoffAcceptPayload",
       "payload": { "handoff_id": "h1", "accepted_by": "agent://target", "reason": "ready" },
       "expect": "accept"
     },
     {
       "sender": "agent://owner",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "handoff.accepted",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/handoff_reject_paths.json
+++ b/schemas/conformance/handoff_reject_paths.json
@@ -13,7 +13,7 @@
     {
       "sender": "agent://target",
       "message_type": "HandoffAccept",
-      "payload_type": "handoff.HandoffAccept",
+      "payload_type": "macp.modes.handoff.v1.HandoffAcceptPayload",
       "payload": {
         "handoff_id": "h1",
         "accepted_by": "agent://target",
@@ -25,7 +25,7 @@
     {
       "sender": "agent://owner",
       "message_type": "HandoffOffer",
-      "payload_type": "handoff.HandoffOffer",
+      "payload_type": "macp.modes.handoff.v1.HandoffOfferPayload",
       "payload": {
         "handoff_id": "h1",
         "target_participant": "agent://target",
@@ -37,7 +37,7 @@
     {
       "sender": "agent://target",
       "message_type": "HandoffAccept",
-      "payload_type": "handoff.HandoffAccept",
+      "payload_type": "macp.modes.handoff.v1.HandoffAcceptPayload",
       "payload": {
         "handoff_id": "h1",
         "accepted_by": "agent://target",
@@ -48,7 +48,7 @@
     {
       "sender": "agent://owner",
       "message_type": "HandoffContext",
-      "payload_type": "handoff.HandoffContext",
+      "payload_type": "macp.modes.handoff.v1.HandoffContextPayload",
       "payload": {
         "handoff_id": "h1",
         "content_type": "text/plain",

--- a/schemas/conformance/lint_fixtures.py
+++ b/schemas/conformance/lint_fixtures.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 REQUIRED_TOP_LEVEL = ("mode", "initiator", "participants", "messages", "expected_final_state")
 VALID_EXPECT = {"accept", "reject"}
-VALID_FINAL_STATE = {"Open", "Resolved", "Suspended", "Cancelled"}
+VALID_FINAL_STATE = {"Open", "Resolved", "Expired", "Suspended", "Cancelled"}
 # Schema versions a conformant runtime is expected to accept for an inline policy
 # (RFC-MACP-0012 §3). Additive: 1 is legacy, 2 adds Decision decline-gating.
 VALID_POLICY_SCHEMA_VERSIONS = {1, 2}
@@ -43,8 +43,15 @@ def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
 
     participants = set(data["participants"])
     initiator = data["initiator"]
-    if initiator not in participants:
-        errors.append(f"initiator {initiator!r} is not in participants")
+    # Initiator membership is mode-specific. Only the delegated model
+    # (handoff) intrinsically binds the initiator into the participant set
+    # (RFC-MACP-0010 §2 — the owner IS a transfer party). Everywhere else the
+    # initiator's authority is role-based, not membership-based (RFC-0007 §2;
+    # RFC-0011 §2 explicitly separates the coordinator from the voter pool;
+    # RFC-0009 authorizes TaskRequest by role) — an external coordinator
+    # outside the participant list is a legitimate, RFC-faithful shape.
+    if data["mode"] == "macp.mode.handoff.v1" and initiator not in participants:
+        errors.append(f"initiator {initiator!r} is not in participants (delegated model requires it)")
 
     final_state = data["expected_final_state"]
     if final_state not in VALID_FINAL_STATE:
@@ -86,9 +93,24 @@ def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
         expect = msg.get("expect")
         if expect not in VALID_EXPECT:
             errors.append(f"messages[{i}].expect {expect!r} not in {sorted(VALID_EXPECT)}")
-        # An ACCEPTED message must come from a participant; a REJECTED message
-        # may legitimately come from an outsider (that is often why it rejects).
-        if expect == "accept" and msg.get("sender") not in participants:
+        # An ACCEPTED message must come from a participant — except the
+        # initiator's role-based messages (SessionStart / Commitment /
+        # CancelSession), which do not require participant-list membership
+        # (see the initiator note above). A REJECTED message may legitimately
+        # come from an outsider (that is often why it rejects).
+        initiator_role_messages = {"SessionStart", "Commitment", "CancelSession"}
+        # Mode-specific messages that are likewise issued by the initiator
+        # ROLE: the quorum coordinator poses the question (RFC-0011 §2), the
+        # task requester issues the request (RFC-0009 §4).
+        initiator_role_messages |= {
+            "macp.mode.quorum.v1": {"ApprovalRequest"},
+            "macp.mode.task.v1": {"TaskRequest"},
+        }.get(data["mode"], set())
+        sender_ok = msg.get("sender") in participants or (
+            msg.get("sender") == initiator
+            and msg.get("message_type") in initiator_role_messages
+        )
+        if expect == "accept" and not sender_ok:
             errors.append(
                 f"messages[{i}] accepted message from non-participant {msg.get('sender')!r}"
             )
@@ -102,7 +124,8 @@ def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
 
 def main() -> int:
     fixtures_dir = Path(__file__).parent
-    fixtures = sorted(fixtures_dir.glob("*.json"))
+    # schema.json is the fixture JSON Schema, not a fixture itself.
+    fixtures = sorted(f for f in fixtures_dir.glob("*.json") if f.name != "schema.json")
     if not fixtures:
         print(f"No fixtures found in {fixtures_dir}", file=sys.stderr)
         return 1

--- a/schemas/conformance/multi_round_happy_path.json
+++ b/schemas/conformance/multi_round_happy_path.json
@@ -1,11 +1,7 @@
 {
   "mode": "ext.multi_round.v1",
   "initiator": "agent://coordinator",
-  "participants": [
-    "agent://coordinator",
-    "agent://alice",
-    "agent://bob"
-  ],
+  "participants": ["agent://alice", "agent://bob"],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -14,43 +10,37 @@
     {
       "sender": "agent://alice",
       "message_type": "Contribute",
-      "payload_type": "multi_round.Contribute",
-      "payload": {
-        "value": "option_a"
-      },
+      "payload_type": "macp.modes.multi_round.v1.ContributePayload",
+      "payload": { "value": "option_a" },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
-      "payload_type": "multi_round.Contribute",
-      "payload": {
-        "value": "option_b"
-      },
+      "payload_type": "macp.modes.multi_round.v1.ContributePayload",
+      "payload": { "value": "option_b" },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
-      "payload_type": "multi_round.Contribute",
-      "payload": {
-        "value": "option_a"
-      },
+      "payload_type": "macp.modes.multi_round.v1.ContributePayload",
+      "payload": { "value": "option_a" },
       "expect": "accept"
     },
     {
       "sender": "agent://coordinator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "multi_round.converged",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/multi_round_reject_paths.json
+++ b/schemas/conformance/multi_round_reject_paths.json
@@ -2,7 +2,6 @@
   "mode": "ext.multi_round.v1",
   "initiator": "agent://coordinator",
   "participants": [
-    "agent://coordinator",
     "agent://alice",
     "agent://bob"
   ],
@@ -14,23 +13,24 @@
     {
       "sender": "agent://coordinator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "multi_round.converged",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
-      "expect": "reject"
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     },
     {
       "sender": "agent://alice",
       "message_type": "Contribute",
-      "payload_type": "multi_round.Contribute",
+      "payload_type": "macp.modes.multi_round.v1.ContributePayload",
       "payload": {
         "value": "option_a"
       },
@@ -39,7 +39,7 @@
     {
       "sender": "agent://bob",
       "message_type": "Contribute",
-      "payload_type": "multi_round.Contribute",
+      "payload_type": "macp.modes.multi_round.v1.ContributePayload",
       "payload": {
         "value": "option_a"
       },
@@ -48,18 +48,19 @@
     {
       "sender": "agent://alice",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "multi_round.converged",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
-      "expect": "reject"
+      "expect": "reject",
+      "expected_error_code": "FORBIDDEN"
     }
   ],
   "expected_final_state": "Open"

--- a/schemas/conformance/proposal_happy_path.json
+++ b/schemas/conformance/proposal_happy_path.json
@@ -13,7 +13,7 @@
     {
       "sender": "agent://seller",
       "message_type": "Proposal",
-      "payload_type": "proposal.Proposal",
+      "payload_type": "macp.modes.proposal.v1.ProposalPayload",
       "payload": {
         "proposal_id": "p1",
         "title": "offer",
@@ -26,7 +26,7 @@
     {
       "sender": "agent://buyer",
       "message_type": "Accept",
-      "payload_type": "proposal.Accept",
+      "payload_type": "macp.modes.proposal.v1.AcceptPayload",
       "payload": {
         "proposal_id": "p1",
         "reason": ""
@@ -36,7 +36,7 @@
     {
       "sender": "agent://seller",
       "message_type": "Accept",
-      "payload_type": "proposal.Accept",
+      "payload_type": "macp.modes.proposal.v1.AcceptPayload",
       "payload": {
         "proposal_id": "p1",
         "reason": ""
@@ -46,16 +46,16 @@
     {
       "sender": "agent://buyer",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "proposal.accepted",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/proposal_reject_paths.json
+++ b/schemas/conformance/proposal_reject_paths.json
@@ -13,16 +13,16 @@
     {
       "sender": "agent://buyer",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "proposal.accepted",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "reject",
       "expected_error_code": "INVALID_ENVELOPE"
@@ -30,7 +30,7 @@
     {
       "sender": "agent://seller",
       "message_type": "CounterProposal",
-      "payload_type": "proposal.CounterProposal",
+      "payload_type": "macp.modes.proposal.v1.CounterProposalPayload",
       "payload": {
         "proposal_id": "p2",
         "supersedes_proposal_id": "",

--- a/schemas/conformance/quorum_happy_path.json
+++ b/schemas/conformance/quorum_happy_path.json
@@ -1,12 +1,7 @@
 {
   "mode": "macp.mode.quorum.v1",
   "initiator": "agent://coordinator",
-  "participants": [
-    "agent://coordinator",
-    "agent://alice",
-    "agent://bob",
-    "agent://carol"
-  ],
+  "participants": ["agent://alice", "agent://bob", "agent://carol"],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -15,49 +10,37 @@
     {
       "sender": "agent://coordinator",
       "message_type": "ApprovalRequest",
-      "payload_type": "quorum.ApprovalRequest",
-      "payload": {
-        "request_id": "r1",
-        "action": "deploy",
-        "summary": "Deploy v2",
-        "details": [],
-        "required_approvals": 2
-      },
+      "payload_type": "macp.modes.quorum.v1.ApprovalRequestPayload",
+      "payload": { "request_id": "r1", "action": "deploy", "summary": "Deploy v2", "details": [], "required_approvals": 2 },
       "expect": "accept"
     },
     {
       "sender": "agent://alice",
       "message_type": "Approve",
-      "payload_type": "quorum.Approve",
-      "payload": {
-        "request_id": "r1",
-        "reason": "lgtm"
-      },
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
+      "payload": { "request_id": "r1", "reason": "lgtm" },
       "expect": "accept"
     },
     {
       "sender": "agent://bob",
       "message_type": "Approve",
-      "payload_type": "quorum.Approve",
-      "payload": {
-        "request_id": "r1",
-        "reason": "ship it"
-      },
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
+      "payload": { "request_id": "r1", "reason": "ship it" },
       "expect": "accept"
     },
     {
       "sender": "agent://coordinator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "quorum.approved",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/quorum_reject_paths.json
+++ b/schemas/conformance/quorum_reject_paths.json
@@ -2,7 +2,6 @@
   "mode": "macp.mode.quorum.v1",
   "initiator": "agent://coordinator",
   "participants": [
-    "agent://coordinator",
     "agent://alice",
     "agent://bob",
     "agent://carol"
@@ -15,17 +14,18 @@
     {
       "sender": "agent://alice",
       "message_type": "Approve",
-      "payload_type": "quorum.Approve",
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
       "payload": {
         "request_id": "r1",
         "reason": "lgtm"
       },
-      "expect": "reject"
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     },
     {
       "sender": "agent://coordinator",
       "message_type": "ApprovalRequest",
-      "payload_type": "quorum.ApprovalRequest",
+      "payload_type": "macp.modes.quorum.v1.ApprovalRequestPayload",
       "payload": {
         "request_id": "r1",
         "action": "deploy",
@@ -37,7 +37,7 @@
     {
       "sender": "agent://alice",
       "message_type": "Approve",
-      "payload_type": "quorum.Approve",
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
       "payload": {
         "request_id": "r1",
         "reason": "lgtm"
@@ -47,18 +47,19 @@
     {
       "sender": "agent://coordinator",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "quorum.approved",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
-      "expect": "reject"
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     }
   ],
   "expected_final_state": "Open"

--- a/schemas/conformance/schema.json
+++ b/schemas/conformance/schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://multiagentcoordinationprotocol.io/schemas/conformance-fixture.schema.json",
+  "title": "MACP mode conformance fixture",
+  "description": "A scripted session transcript with per-message accept/reject expectations, runnable against any MACP runtime.",
+  "type": "object",
+  "required": [
+    "mode",
+    "initiator",
+    "participants",
+    "mode_version",
+    "configuration_version",
+    "ttl_ms",
+    "messages",
+    "expected_final_state"
+  ],
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "mode": {
+      "type": "string",
+      "pattern": "^(macp\\.mode\\.[a-z_]+\\.v\\d+|ext\\.[a-z_.]+\\.v\\d+)$"
+    },
+    "initiator": {
+      "type": "string",
+      "minLength": 1
+    },
+    "participants": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "mode_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "configuration_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "policy_version": {
+      "type": "string"
+    },
+    "ttl_ms": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "messages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "sender",
+          "message_type",
+          "payload_type",
+          "payload",
+          "expect"
+        ],
+        "properties": {
+          "sender": {
+            "type": "string",
+            "minLength": 1
+          },
+          "message_type": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payload_type": {
+            "type": "string",
+            "description": "Fully-qualified protobuf message name",
+            "pattern": "^(macp\\.v1\\.[A-Za-z]+|macp\\.modes\\.[a-z_]+\\.v\\d+\\.[A-Za-z]+Payload)$"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "expect": {
+            "enum": [
+              "accept",
+              "reject"
+            ]
+          },
+          "expected_error_code": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "expected_final_state": {
+      "enum": [
+        "Open",
+        "Suspended",
+        "Resolved",
+        "Expired",
+        "Cancelled"
+      ]
+    },
+    "expected_resolution": {
+      "type": "object"
+    },
+    "expected_mode_state": {
+      "type": "object"
+    },
+    "expect_resolution_present": {
+      "type": "boolean"
+    },
+    "verify_replay_equivalence": {
+      "type": "boolean"
+    },
+    "policy": {
+      "type": "object",
+      "description": "Optional inline PolicyDefinition registered before SessionStart"
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/conformance/task_happy_path.json
+++ b/schemas/conformance/task_happy_path.json
@@ -10,37 +10,37 @@
     {
       "sender": "agent://planner",
       "message_type": "TaskRequest",
-      "payload_type": "task.TaskRequest",
+      "payload_type": "macp.modes.task.v1.TaskRequestPayload",
       "payload": { "task_id": "t1", "title": "Build", "instructions": "Do it", "requested_assignee": "agent://worker", "input": [], "deadline_unix_ms": 0 },
       "expect": "accept"
     },
     {
       "sender": "agent://worker",
       "message_type": "TaskAccept",
-      "payload_type": "task.TaskAccept",
+      "payload_type": "macp.modes.task.v1.TaskAcceptPayload",
       "payload": { "task_id": "t1", "assignee": "agent://worker", "reason": "ready" },
       "expect": "accept"
     },
     {
       "sender": "agent://worker",
       "message_type": "TaskComplete",
-      "payload_type": "task.TaskComplete",
+      "payload_type": "macp.modes.task.v1.TaskCompletePayload",
       "payload": { "task_id": "t1", "assignee": "agent://worker", "output": [], "summary": "done" },
       "expect": "accept"
     },
     {
       "sender": "agent://planner",
       "message_type": "Commitment",
-      "payload_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
       "payload": {
         "commitment_id": "c1",
-        "outcome_positive": true,
         "action": "task.completed",
         "authority_scope": "test",
         "reason": "done",
         "mode_version": "1.0.0",
-        "policy_version": "",
-        "configuration_version": "cfg-1"
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": true
       },
       "expect": "accept"
     }

--- a/schemas/conformance/task_reject_paths.json
+++ b/schemas/conformance/task_reject_paths.json
@@ -1,7 +1,10 @@
 {
   "mode": "macp.mode.task.v1",
   "initiator": "agent://planner",
-  "participants": ["agent://planner", "agent://worker"],
+  "participants": [
+    "agent://planner",
+    "agent://worker"
+  ],
   "mode_version": "1.0.0",
   "configuration_version": "cfg-1",
   "policy_version": "",
@@ -10,23 +13,43 @@
     {
       "sender": "agent://worker",
       "message_type": "TaskRequest",
-      "payload_type": "task.TaskRequest",
-      "payload": { "task_id": "t1", "title": "Build", "instructions": "Do it", "requested_assignee": "agent://worker", "deadline_unix_ms": 0 },
-      "expect": "reject"
+      "payload_type": "macp.modes.task.v1.TaskRequestPayload",
+      "payload": {
+        "task_id": "t1",
+        "title": "Build",
+        "instructions": "Do it",
+        "requested_assignee": "agent://worker",
+        "deadline_unix_ms": 0
+      },
+      "expect": "reject",
+      "expected_error_code": "FORBIDDEN"
     },
     {
       "sender": "agent://planner",
       "message_type": "TaskRequest",
-      "payload_type": "task.TaskRequest",
-      "payload": { "task_id": "t1", "title": "Build", "instructions": "Do it", "requested_assignee": "agent://worker", "deadline_unix_ms": 0 },
+      "payload_type": "macp.modes.task.v1.TaskRequestPayload",
+      "payload": {
+        "task_id": "t1",
+        "title": "Build",
+        "instructions": "Do it",
+        "requested_assignee": "agent://worker",
+        "deadline_unix_ms": 0
+      },
       "expect": "accept"
     },
     {
       "sender": "agent://planner",
       "message_type": "TaskRequest",
-      "payload_type": "task.TaskRequest",
-      "payload": { "task_id": "t2", "title": "Another", "instructions": "Do more", "requested_assignee": "agent://worker", "deadline_unix_ms": 0 },
-      "expect": "reject"
+      "payload_type": "macp.modes.task.v1.TaskRequestPayload",
+      "payload": {
+        "task_id": "t2",
+        "title": "Another",
+        "instructions": "Do more",
+        "requested_assignee": "agent://worker",
+        "deadline_unix_ms": 0
+      },
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     }
   ],
   "expected_final_state": "Open"


### PR DESCRIPTION
Step 1 of #44 (single canonical fixture source). Companion runtime PR adds the CI oracle that consumes this directory.

## What

- **Fixtures**: the 13 fixtures replaced with the runtime-verified canonical set. The old copies predated the runtime's format canonicalization — shorthand `payload_type`s (`decision.Proposal`), pre-RFC participant shapes. New set: fully-qualified proto names, documented vote casing, and **`expected_error_code` on every reject message** — every code verified by running the runtime's conformance harness (14/14 green, incl. replay-equivalence checks).
- **`schema.json`**: draft-2020-12 JSON Schema for the fixture format (previously only in the runtime repo).
- **Linter**: `initiator ∈ participants` is now **mode-aware** — only handoff's delegated model requires membership (RFC-0010 §2). Quorum's coordinator is *explicitly* outside the voter pool (RFC-0011 §2) and Task authorizes `TaskRequest` by role (RFC-0009 §4), so the blanket rule was rejecting the RFC-faithful shapes. Role-based initiator messages accepted from non-participant initiators; `Expired` added to valid final states; `schema.json` excluded from fixture linting.
- **README**: documents the single-source contract (fixtures land here first; the runtime vendors byte-identical copies checked by its CI oracle).

## Verification
- `lint_fixtures.py`: all 13 fixtures pass, zero warnings.
- Runtime conformance suite against these exact bytes: 14/14.