### PR TITLE
feat(handoff): specify the implicit-accept timer contract (RFC-0010 §5.1)

### DIFF
--- a/packages/proto-npm/proto/macp/modes/handoff/v1/handoff.proto
+++ b/packages/proto-npm/proto/macp/modes/handoff/v1/handoff.proto
@@ -19,6 +19,10 @@ message HandoffAcceptPayload {
   string handoff_id = 1;
   string accepted_by = 2;
   string reason = 3;
+  // True on the runtime-emitted synthetic accept produced by
+  // acceptance.implicit_accept_timeout_ms (RFC-MACP-0010 §5.1). Clients
+  // MUST NOT submit an accept with implicit = true; runtimes MUST reject it.
+  bool implicit = 4;
 }
 
 message HandoffDeclinePayload {

--- a/packages/proto-rust/proto/macp/modes/handoff/v1/handoff.proto
+++ b/packages/proto-rust/proto/macp/modes/handoff/v1/handoff.proto
@@ -19,6 +19,10 @@ message HandoffAcceptPayload {
   string handoff_id = 1;
   string accepted_by = 2;
   string reason = 3;
+  // True on the runtime-emitted synthetic accept produced by
+  // acceptance.implicit_accept_timeout_ms (RFC-MACP-0010 §5.1). Clients
+  // MUST NOT submit an accept with implicit = true; runtimes MUST reject it.
+  bool implicit = 4;
 }
 
 message HandoffDeclinePayload {

--- a/rfcs/RFC-MACP-0010-handoff-mode.md
+++ b/rfcs/RFC-MACP-0010-handoff-mode.md
@@ -68,6 +68,53 @@ Implementations MUST enforce the following:
 4. Once an offer has been accepted, no competing accept for that same `handoff_id` is valid.
 5. A Session MAY contain multiple sequential handoff offers to different targets. At most one offer may be outstanding (unaccepted and undeclined) at any time. A new `HandoffOffer` MUST NOT be issued while a prior offer is still pending. Once an offer is accepted, no further offers may be issued for the Session. Only one final `Commitment` may resolve the Session.
 
+### 5.1 Implicit acceptance (synthetic accept)
+
+A bound governance policy MAY declare `acceptance.implicit_accept_timeout_ms`
+(RFC-MACP-0012 §4.5). When it is non-zero, an outstanding offer that the
+target has neither accepted nor declined within the timeout is accepted
+implicitly, under the following contract:
+
+1. **Timing source.** The timeout is measured on the **session timeline**
+   from the runtime's recorded acceptance time of the `HandoffOffer` (the
+   offer log entry's acceptance timestamp) — never from client-supplied
+   envelope timestamps, which are forgeable. Time during which the session
+   is `SUSPENDED` does **not** count toward the timeout: the deadline is
+   reached when the *unsuspended* elapsed session time since offer
+   acceptance meets or exceeds the timeout. Every input to this computation
+   (the offer's recorded acceptance time and the suspend/resume events) is
+   on the recorded timeline.
+
+2. **The synthetic accept enters history.** When the runtime first observes
+   the deadline elapsed, it MUST append a synthetic `HandoffAccept` envelope
+   to the session's accepted history — before evaluating any subsequent
+   message against the offer's acceptance state, and in particular **before
+   any `Commitment` evaluation** that depends on the offer being accepted. A
+   runtime SHOULD observe the deadline eagerly (a timer or sweep, like TTL
+   expiry); it MUST observe it lazily at the latest when processing the next
+   session-scoped message. Because the synthetic accept is an accepted
+   history entry, replay simply replays it: the timer itself is outside the
+   replay boundary, its recorded product is inside — the same construction
+   as runtime-emitted `SessionSuspend`/`SessionResume`/`SessionCancel`
+   envelopes (RFC-MACP-0001 §7.5).
+
+3. **Envelope convention.** The synthetic accept is runtime-emitted; clients
+   MUST NOT submit it via `Send`. Its Envelope `sender` is the offer's
+   `target_participant` (acceptance occurs on the target's behalf, keeping
+   validation rule 3 coherent), `HandoffAcceptPayload.implicit` MUST be
+   `true`, and `accepted_by` MUST be the target. The Envelope
+   `timestamp_unix_ms` SHOULD be the computed deadline (offer acceptance
+   time + timeout + suspended time within the window), not the observation
+   time. The `message_id` MUST be deterministic per offer (RECOMMENDED:
+   `implicit-accept:<handoff_id>`), making emission idempotent under
+   at-least-once processing. A client-submitted `HandoffAccept` carrying
+   `implicit: true` MUST be rejected.
+
+4. **Races resolve by history order.** An explicit `HandoffAccept` or
+   `HandoffDecline` accepted into history before the synthetic accept
+   settles the offer, and the synthetic accept is then never emitted. Once
+   the synthetic accept is in history, a later decline is invalid (rule 4).
+
 ## 6. Terminal semantics
 
 Handoff Mode resolves only when an authorized `Commitment` is accepted.

--- a/rfcs/RFC-MACP-0012-policy.md
+++ b/rfcs/RFC-MACP-0012-policy.md
@@ -145,7 +145,7 @@ Canonical schema: `schemas/json/policy/handoff-rules.schema.json`
 | `acceptance` | `implicit_accept_timeout_ms` | Auto-accept after timeout (0 = no implicit accept) |
 | `commitment` | `authority` | Who can emit the terminal `Commitment` |
 
-**Determinism note:** `implicit_accept_timeout_ms` is **not** evaluated by the policy evaluator at commitment time. It is a declarative parameter consumed by the mode's timer/TTL mechanism, which emits a synthetic accept event into the session history before any commitment evaluation occurs. The policy evaluator only sees the resulting accepted message history, preserving the determinism requirement of Section 6.3.
+**Determinism note:** `implicit_accept_timeout_ms` is **not** evaluated by the policy evaluator at commitment time. It is a declarative parameter consumed by the runtime's synthetic-accept mechanism, whose full normative contract — timing source (the offer's recorded acceptance time on the session timeline, excluding suspended time), lazy-at-the-latest emission into accepted history before commitment evaluation, runtime-emitted envelope convention (`sender` = target, `HandoffAcceptPayload.implicit = true`, deterministic `message_id`), and race resolution by history order — is defined in RFC-MACP-0010 §5.1. The policy evaluator only sees the resulting accepted message history, preserving the determinism requirement of Section 6.3: the timer is outside the replay boundary, its recorded product is inside.
 
 ### 4.6 Extension Mode Rules
 

--- a/schemas/proto/macp/modes/handoff/v1/handoff.proto
+++ b/schemas/proto/macp/modes/handoff/v1/handoff.proto
@@ -19,6 +19,10 @@ message HandoffAcceptPayload {
   string handoff_id = 1;
   string accepted_by = 2;
   string reason = 3;
+  // True on the runtime-emitted synthetic accept produced by
+  // acceptance.implicit_accept_timeout_ms (RFC-MACP-0010 §5.1). Clients
+  // MUST NOT submit an accept with implicit = true; runtimes MUST reject it.
+  bool implicit = 4;
 }
 
 message HandoffDeclinePayload {


### PR DESCRIPTION
Closes #35 — the last freeze-blocking decision without a spec PR.

## Problem
RFC-0012 §4.5 said `implicit_accept_timeout_ms` is "consumed by a timer that emits a synthetic accept into history" — but specified **no timing source, no authority (whose message is the synthetic accept?), no determinism story, and no suspension interaction**. No conformant implementation was possible; macp-runtime ships an interim mitigation (acceptance-clock timing inside the Commitment handler, its A6 change).

## The contract (new RFC-0010 §5.1)

The design principle: **the timer is outside the replay boundary; its product — a synthetic accept in accepted history — is inside.** Same construction as runtime-emitted `SessionSuspend`/`SessionResume`/`SessionCancel`.

1. **Timing**: measured from the offer's *recorded* acceptance time on the session timeline (client envelope timestamps are forgeable — this is the same trust fix macp-runtime's A6 made); `SUSPENDED` time doesn't count.
2. **Emission**: the synthetic `HandoffAccept` MUST be in accepted history before any commitment evaluation that depends on the offer's acceptance — eager (timer/sweep) is SHOULD, lazy-on-next-message is the MUST floor. Replay just replays the recorded envelope; nothing is re-derived.
3. **Envelope convention**: runtime-emitted (clients MUST NOT submit it); `sender` = `target_participant` so validation rule 3 stays coherent; **new proto field** `HandoffAcceptPayload.implicit = true` marks it auditable; deterministic `message_id` (`implicit-accept:<handoff_id>`) makes emission idempotent; `timestamp_unix_ms` = the computed deadline. A client-submitted accept with `implicit: true` is rejected.
4. **Races**: history order decides — an explicit accept/decline that lands first wins; after the synthetic accept, a decline is invalid.

## Changes
- RFC-0010: new §5.1 (full contract)
- RFC-0012 §4.5: determinism note now points at the contract instead of hand-waving
- `handoff.proto`: `HandoffAcceptPayload.implicit = 4` (backward-compatible addition; `buf breaking` clean); packages synced

## After merge
The new proto field ships in the next `macp-proto` release — suggest bundling with the ListSessions pagination fields (issue #38, PR imminent) as **0.1.6**. macp-runtime then implements the timer, replacing its A6 interim fix (gated on a new semantics rev, per its established migration pattern).