### PR TITLE
feat(core): ListSessions pagination (page_size / page_token / next_page_token)

### DIFF
--- a/packages/proto-npm/proto/macp/v1/core.proto
+++ b/packages/proto-npm/proto/macp/v1/core.proto
@@ -408,10 +408,21 @@ message WatchSignalsResponse {
 // active sessions (initial sync); subsequent responses carry individual
 // lifecycle transitions.
 
-message ListSessionsRequest {}
+message ListSessionsRequest {
+  // Maximum sessions to return. 0 = server-chosen default. Servers MAY cap
+  // the effective size; clients MUST NOT assume the response is complete
+  // unless next_page_token is empty.
+  int32 page_size = 1;
+  // Opaque continuation token from a previous ListSessionsResponse. Empty =
+  // first page. Tokens are short-lived and implementation-defined; a stale
+  // token yields INVALID_ARGUMENT.
+  string page_token = 2;
+}
 
 message ListSessionsResponse {
   repeated SessionMetadata sessions = 1;
+  // Non-empty when more results exist; pass back verbatim as page_token.
+  string next_page_token = 2;
 }
 
 message WatchSessionsRequest {}

--- a/packages/proto-rust/proto/macp/v1/core.proto
+++ b/packages/proto-rust/proto/macp/v1/core.proto
@@ -408,10 +408,21 @@ message WatchSignalsResponse {
 // active sessions (initial sync); subsequent responses carry individual
 // lifecycle transitions.
 
-message ListSessionsRequest {}
+message ListSessionsRequest {
+  // Maximum sessions to return. 0 = server-chosen default. Servers MAY cap
+  // the effective size; clients MUST NOT assume the response is complete
+  // unless next_page_token is empty.
+  int32 page_size = 1;
+  // Opaque continuation token from a previous ListSessionsResponse. Empty =
+  // first page. Tokens are short-lived and implementation-defined; a stale
+  // token yields INVALID_ARGUMENT.
+  string page_token = 2;
+}
 
 message ListSessionsResponse {
   repeated SessionMetadata sessions = 1;
+  // Non-empty when more results exist; pass back verbatim as page_token.
+  string next_page_token = 2;
 }
 
 message WatchSessionsRequest {}

--- a/schemas/proto/macp/v1/core.proto
+++ b/schemas/proto/macp/v1/core.proto
@@ -408,10 +408,21 @@ message WatchSignalsResponse {
 // active sessions (initial sync); subsequent responses carry individual
 // lifecycle transitions.
 
-message ListSessionsRequest {}
+message ListSessionsRequest {
+  // Maximum sessions to return. 0 = server-chosen default. Servers MAY cap
+  // the effective size; clients MUST NOT assume the response is complete
+  // unless next_page_token is empty.
+  int32 page_size = 1;
+  // Opaque continuation token from a previous ListSessionsResponse. Empty =
+  // first page. Tokens are short-lived and implementation-defined; a stale
+  // token yields INVALID_ARGUMENT.
+  string page_token = 2;
+}
 
 message ListSessionsResponse {
   repeated SessionMetadata sessions = 1;
+  // Non-empty when more results exist; pass back verbatim as page_token.
+  string next_page_token = 2;
 }
 
 message WatchSessionsRequest {}


### PR DESCRIPTION
Closes #38.

Standard page-token pagination for `ListSessions` — `page_size`/`page_token` on the request, `next_page_token` on the response. Pure proto3-compatible field additions (`buf breaking` clean): existing clients send 0/empty and servers may cap the page and set `next_page_token`, which old clients ignore (they see a capped-but-valid response; the cap should be documented server-side, which macp-runtime already does in deployment.md).

Suggest releasing as `macp-proto` **0.1.6** together with the `HandoffAcceptPayload.implicit` field from #50 — one release for both pending proto additions. Runtime-side implementation (server cap → real pagination) follows the release.