### PR TITLE
docs: fix drift batch — context_id, lifecycle events, schema_version comment, SessionEnd, RFC index (closes #40)

### DIFF
--- a/packages/proto-npm/proto/macp/v1/policy.proto
+++ b/packages/proto-npm/proto/macp/v1/policy.proto
@@ -19,7 +19,7 @@ message PolicyDescriptor {
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
   string rules = 4;
 
-  // Version of the rule schema used (currently 1).
+  // Version of the rule schema used (RFC-MACP-0012 defines versions 1 and 2).
   uint32 schema_version = 5;
 
   int64 registered_at_unix_ms = 6; // Unix epoch milliseconds; set by the runtime, ignored in RegisterPolicyRequest.

--- a/packages/proto-rust/proto/macp/v1/policy.proto
+++ b/packages/proto-rust/proto/macp/v1/policy.proto
@@ -19,7 +19,7 @@ message PolicyDescriptor {
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
   string rules = 4;
 
-  // Version of the rule schema used (currently 1).
+  // Version of the rule schema used (RFC-MACP-0012 defines versions 1 and 2).
   uint32 schema_version = 5;
 
   int64 registered_at_unix_ms = 6; // Unix epoch milliseconds; set by the runtime, ignored in RegisterPolicyRequest.

--- a/rfcs/RFC-MACP-0001.md
+++ b/rfcs/RFC-MACP-0001.md
@@ -15,6 +15,7 @@ The MACP standards set has been split into focused documents.
 - [RFC-MACP-0009 Task Mode](RFC-MACP-0009-task-mode.md)
 - [RFC-MACP-0010 Handoff Mode](RFC-MACP-0010-handoff-mode.md)
 - [RFC-MACP-0011 Quorum Mode](RFC-MACP-0011-quorum-mode.md)
+- [RFC-MACP-0012 Governance Policy Framework](RFC-MACP-0012-policy.md)
 
 ## Notes
 

--- a/rfcs/RFC-MACP-0003-determinism.md
+++ b/rfcs/RFC-MACP-0003-determinism.md
@@ -107,7 +107,7 @@ The determinism classes defined by RFC-MACP-0002 are normative for descriptors a
 
 - **semantic-deterministic**: Replay reproduces identical lifecycle transitions AND the same semantic outcome — the terminal action, committed values, and resolution are identical given the same accepted envelope sequence.
 
-- **context-frozen**: Same guarantees as semantic-deterministic, but ONLY when the external context bound at `SessionStart` (via `context` and `roots`) is replayed exactly. If bound context differs from the original session, replay outcomes are undefined.
+- **context-frozen**: Same guarantees as semantic-deterministic, but ONLY when the external context bound at `SessionStart` (via `context_id`, `extensions`, and `roots`) is replayed exactly. If bound context differs from the original session, replay outcomes are undefined.
 
 - **non-deterministic**: Replay reproduces identical lifecycle transitions and accept/reject decisions, but semantic outcomes may differ due to runtime state or external side effects. Runtimes SHOULD NOT attempt semantic replay for non-deterministic modes.
 

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -154,7 +154,7 @@ rpc WatchSessions(WatchSessionsRequest) returns (stream WatchSessionsResponse);
 
 `ListSessions` returns `SessionMetadata` for all currently known sessions (active and terminal). A runtime MUST advertise `sessions.list_sessions = true` before `ListSessions` can be assumed interoperable.
 
-`WatchSessions` is a server-streaming RPC that emits `SessionLifecycleEvent` notifications. Each event carries an `EventType` (CREATED, RESOLVED, or EXPIRED), the affected `SessionMetadata`, and an `observed_at_unix_ms` timestamp. A runtime MUST advertise `sessions.watch_sessions = true` before `WatchSessions` can be assumed interoperable.
+`WatchSessions` is a server-streaming RPC that emits `SessionLifecycleEvent` notifications. Each event carries an `EventType` (CREATED, RESOLVED, EXPIRED, SUSPENDED, RESUMED, or CANCELLED), the affected `SessionMetadata`, and an `observed_at_unix_ms` timestamp. A runtime MUST advertise `sessions.watch_sessions = true` before `WatchSessions` can be assumed interoperable.
 
 Session lifecycle events are ephemeral — they are not persisted and are not available for replay. Clients that disconnect MAY miss events. Control-planes and UIs SHOULD use `ListSessions` for initial sync and `WatchSessions` for incremental updates.
 

--- a/rfcs/RFC-MACP-0007-decision-mode.md
+++ b/rfcs/RFC-MACP-0007-decision-mode.md
@@ -50,7 +50,7 @@ A Decision Mode Session MUST bind the following fields explicitly in `SessionSta
 - `configuration_version` - voting or evaluation profile,
 - `policy_version` — governance profile (MAY be empty; when empty, the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
 - `ttl_ms` - explicit decision deadline,
-- `context` - optional bound decision context.
+- `context_id` - optional bound decision context reference (arbitrary attached data goes in `extensions`).
 
 ## 4. Message types
 

--- a/rfcs/RFC-MACP-0008-proposal-mode.md
+++ b/rfcs/RFC-MACP-0008-proposal-mode.md
@@ -43,7 +43,7 @@ A Proposal Mode Session MUST bind:
 - `configuration_version` — rule profile for negotiation parameters,
 - `policy_version` — governance profile (MAY be empty; when empty, the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
 - `ttl_ms` - explicit negotiation deadline,
-- `context` - optional negotiation context.
+- `context_id` - optional negotiation context reference (arbitrary attached data goes in `extensions`).
 
 Unless policy states otherwise, the session initiator is the default `Commitment` authority.
 

--- a/rfcs/RFC-MACP-0009-task-mode.md
+++ b/rfcs/RFC-MACP-0009-task-mode.md
@@ -44,7 +44,7 @@ A Task Mode Session MUST bind:
 - `configuration_version` - execution profile,
 - `policy_version` — governance or authorization profile (MAY be empty; when empty, the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
 - `ttl_ms` - task deadline,
-- `context` - optional task context and constraints.
+- `context_id` - optional task context reference (task constraints and other attached data go in `extensions`).
 
 Base Task Mode v1 assumes exactly one task request per Session.
 

--- a/rfcs/RFC-MACP-0010-handoff-mode.md
+++ b/rfcs/RFC-MACP-0010-handoff-mode.md
@@ -45,7 +45,7 @@ A Handoff Mode Session MUST bind:
 - `configuration_version` - transfer profile,
 - `policy_version` — governance profile (MAY be empty; when empty, the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
 - `ttl_ms` - deadline for the transfer,
-- `context` and `roots` - any frozen handoff context or trust boundary needed for replay.
+- `context_id`, `extensions`, and `roots` - any frozen handoff context reference, attached data, or trust boundary needed for replay.
 
 ## 4. Message types
 

--- a/rfcs/RFC-MACP-0011-quorum-mode.md
+++ b/rfcs/RFC-MACP-0011-quorum-mode.md
@@ -44,7 +44,7 @@ A Quorum Mode Session MUST bind:
 - `configuration_version` - approval threshold profile,
 - `policy_version` — governance profile (MAY be empty; when empty, the runtime resolves to `policy.default` per RFC-MACP-0012 Section 5),
 - `ttl_ms` - approval deadline,
-- `context` - optional approval context.
+- `context_id` - optional approval context reference (arbitrary attached data goes in `extensions`).
 
 Base Quorum Mode v1 assumes exactly one approval request per Session.
 

--- a/schemas/proto/macp/v1/policy.proto
+++ b/schemas/proto/macp/v1/policy.proto
@@ -19,7 +19,7 @@ message PolicyDescriptor {
   // (e.g., schemas/json/policy/decision-rules.schema.json for Decision Mode).
   string rules = 4;
 
-  // Version of the rule schema used (currently 1).
+  // Version of the rule schema used (RFC-MACP-0012 defines versions 1 and 2).
   uint32 schema_version = 5;
 
   int64 registered_at_unix_ms = 6; // Unix epoch milliseconds; set by the runtime, ignored in RegisterPolicyRequest.


### PR DESCRIPTION
Fixes the five documentation-drift items from the macp-runtime audit (issue #40).

## Changes

1. **Removed `context` field in mode RFCs** — `SessionStartPayload` replaced `bytes context` with `context_id` (string reference) + `extensions` (map<string,bytes>). Updated the SessionStart binding bullets in:
   - `rfcs/RFC-MACP-0007-decision-mode.md` (§3)
   - `rfcs/RFC-MACP-0008-proposal-mode.md` (§3)
   - `rfcs/RFC-MACP-0009-task-mode.md` (§3)
   - `rfcs/RFC-MACP-0010-handoff-mode.md` (§3, the "`context` and `roots`" bullet)
   - `rfcs/RFC-MACP-0011-quorum-mode.md` (§3)
   - `rfcs/RFC-MACP-0003-determinism.md` (context-frozen determinism class, which named the field)

   `HandoffContextPayload.context` and prose uses of "context" were left untouched.

2. **Stale `SessionLifecycleEvent` text in RFC-0006** — `rfcs/RFC-MACP-0006-transport-bindings.md` (Session Lifecycle Observation RPCs section, numbered §3.8 in the file, not §3.6 as the issue said) now lists the full `EventType` set: CREATED, RESOLVED, EXPIRED, SUSPENDED, RESUMED, CANCELLED, matching `core.proto`.

3. **Stale `schema_version` comment** — `schemas/proto/macp/v1/policy.proto` comment changed from "currently 1" to "RFC-MACP-0012 defines versions 1 and 2". Synced via `./scripts/sync-proto-packages.sh` (updates `packages/proto-npm` and `packages/proto-rust`); `buf lint` clean.

4. **Pre-suspension lifecycle / nonexistent `SessionEnd`** — the drift was in the repo's `CLAUDE.md` only (README.md had none). CLAUDE.md is **gitignored in this repo**, so the fix (full OPEN ⇄ SUSPENDED / RESOLVED | EXPIRED | CANCELLED lifecycle; `SessionSuspend`/`SessionResume` runtime-emitted annotations; `SessionEnd` removed) was applied locally but does not appear in this diff.

5. **RFC index missing RFC-0012** — added `RFC-MACP-0012 Governance Policy Framework` to the index in `rfcs/RFC-MACP-0001.md`.

## Validation

- `buf lint` — clean
- `./scripts/validate-proto.sh` — all schemas compile
- `./scripts/sync-proto-packages.sh --check` — packages in sync
- `python3 schemas/conformance/lint_fixtures.py` — all 13 fixtures consistent (pre-existing advisory warnings only)

Closes #40