### PR TITLE
fix(proto-python): declare the real dependency floors and pin the generator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate Python and verify
         run: |
-          pip install grpcio-tools
+          pip install grpcio-tools==1.82.0  # pinned: keep in sync with publish workflow + proto-python floors
           python -m grpc_tools.protoc \
             -Ischemas/proto \
             --python_out=packages/proto-python/src \

--- a/.github/workflows/publish-proto-packages.yml
+++ b/.github/workflows/publish-proto-packages.yml
@@ -85,7 +85,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install build tools
-        run: pip install build twine grpcio-tools
+        # grpcio-tools is PINNED: the generator version determines the gencode's
+        # real protobuf/grpcio runtime floors, which must equal the floors
+        # declared in packages/proto-python/pyproject.toml. Bump both together.
+        run: pip install build twine grpcio-tools==1.82.0
 
       - name: Generate Python protobuf code
         run: |

--- a/packages/proto-python/pyproject.toml
+++ b/packages/proto-python/pyproject.toml
@@ -19,8 +19,13 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "grpcio>=1.74.0",
-  "protobuf>=5.27.0",
+  # Floors MUST match what the pinned grpcio-tools generator emits (see
+  # publish-proto-packages.yml): gencode from grpcio-tools 1.82 requires
+  # protobuf>=7.35 / grpcio>=1.82 at runtime. Bump these together with the
+  # generator pin (issue #53 shipped wheels whose declared floors were below
+  # what the code could import against).
+  "grpcio>=1.82.0",
+  "protobuf>=7.35.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Closes #53.

**Note on 0.1.7**: the `proto-v0.1.7` tag was cut from a commit without this fix, so its PyPI wheel carries the same wrong floors as 0.1.4–0.1.6. Merging this and tagging **`proto-v0.1.8`** ships the corrected wheel.

## What
- `packages/proto-python/pyproject.toml`: floors raised to the empirically verified requirements of the current gencode — `protobuf>=7.35.0`, `grpcio>=1.82.0` (importing under the previously declared minimums raises `VersionError`; reproduced during macp-sdk-python absorption planning).
- `publish-proto-packages.yml` + `ci.yml`: `grpcio-tools` **pinned to 1.82.0** — the generator version determines the gencode's true runtime floors, so it must be a deliberate choice, bumped together with the declared floors (comments at both sites say so).

The parity-script path staleness noted in #53 is left for a separate cleanup (unrelated to the wheel defect).