### PR TITLE
test: harden validation gates; docs: fix spec drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Generate Python and verify
         run: |
-          pip install grpcio-tools==1.82.0  # pinned: keep in sync with publish workflow + proto-python floors
+          pip install grpcio-tools==1.82.1  # pinned: keep in sync with publish workflow + proto-python floors
           python -m grpc_tools.protoc \
             -Ischemas/proto \
             --python_out=packages/proto-python/src \

--- a/.github/workflows/publish-proto-packages.yml
+++ b/.github/workflows/publish-proto-packages.yml
@@ -88,7 +88,7 @@ jobs:
         # grpcio-tools is PINNED: the generator version determines the gencode's
         # real protobuf/grpcio runtime floors, which must equal the floors
         # declared in packages/proto-python/pyproject.toml. Bump both together.
-        run: pip install build twine grpcio-tools==1.82.0
+        run: pip install build twine grpcio-tools==1.82.1
 
       - name: Generate Python protobuf code
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: help validate validate-all proto-lint proto-compile proto-gen-all json-validate json-schema-validate clean install-tools \
-	gen-go gen-python gen-java gen-kotlin gen-csharp gen-js sync-protos check-proto-sync \
-	check-python-stubs check-go-stubs
+.PHONY: help validate validate-all proto-lint proto-compile proto-gen-all json-validate json-schema-validate \
+	conformance-lint clean install-tools \
+	gen-go gen-python gen-java gen-kotlin gen-csharp gen-js sync-protos check-proto-sync
 
 PROTO_SRC := schemas/proto
 PROTO_FILES := macp/v1/envelope.proto macp/v1/core.proto macp/v1/policy.proto \
@@ -16,6 +16,7 @@ help:
 	@echo "  make validate              Run all validations"
 	@echo "  make json-schema-validate  Validate JSON Schema itself"
 	@echo "  make json-validate         Validate JSON examples against schema"
+	@echo "  make conformance-lint      Lint conformance fixtures (internal consistency)"
 	@echo "  make proto-lint            Lint Protocol Buffer schemas"
 	@echo "  make proto-compile         Compile Protocol Buffer schemas (validation)"
 	@echo ""
@@ -31,8 +32,6 @@ help:
 	@echo "Proto Sync (raw-proto packages):"
 	@echo "  make sync-protos           Copy canonical protos → proto-npm, proto-rust"
 	@echo "  make check-proto-sync      Verify raw-proto packages match canonical (CI guard)"
-	@echo "  make check-python-stubs    Verify committed Python _pb2_grpc.py stubs are current"
-	@echo "  make check-go-stubs        Verify committed Go .pb.go stubs are current"
 	@echo ""
 	@echo "Utilities:"
 	@echo "  make clean                 Remove generated files"
@@ -40,7 +39,7 @@ help:
 	@echo ""
 
 # Validate everything
-validate: json-schema-validate json-validate proto-lint proto-compile check-proto-sync check-python-stubs check-go-stubs
+validate: json-schema-validate json-validate conformance-lint proto-lint proto-compile check-proto-sync
 	@echo "✓ All validations passed"
 
 validate-all: validate proto-gen-all
@@ -55,6 +54,11 @@ json-schema-validate:
 json-validate:
 	@echo "Validating JSON examples..."
 	@./scripts/validate-json.sh
+
+# Lint conformance fixtures for internal consistency (participant membership, expect flow, policy shape)
+conformance-lint:
+	@echo "Linting conformance fixtures..."
+	@python3 schemas/conformance/lint_fixtures.py
 
 # Lint protobuf files with buf
 proto-lint:
@@ -75,16 +79,6 @@ sync-protos:
 check-proto-sync:
 	@echo "Checking proto package sync..."
 	@./scripts/sync-proto-packages.sh --check
-
-# Check that committed Python gRPC stubs match a fresh generation (CI guard)
-check-python-stubs:
-	@echo "Checking Python _pb2_grpc.py stubs..."
-	@./scripts/check-python-stubs.sh
-
-# Check that committed Go protobuf stubs match a fresh generation (CI guard)
-check-go-stubs:
-	@echo "Checking Go .pb.go stubs..."
-	@./scripts/check-go-stubs.sh
 
 # Compile protobuf to validate syntax
 proto-compile:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ MACP/
       task.proto
       handoff.proto
       quorum.proto
+      multi_round.proto
     proto/                    # canonical versioned schemas
       macp/v1/
         envelope.proto
@@ -85,14 +86,21 @@ MACP/
         handoff.proto
       macp/modes/quorum/v1/
         quorum.proto
+      macp/modes/multi_round/v1/
+        multi_round.proto     # ext.multi_round.v1 extension mode
     json/
       macp-envelope.schema.json
       macp-agent-manifest.schema.json
       macp-mode-descriptor.schema.json
       macp-session-metadata.schema.json
+      macp-session-lifecycle-event.schema.json
+      macp-run-descriptor.schema.json
+      macp-agent-bootstrap.schema.json
       macp-ack.schema.json
       macp-error.schema.json
       macp-policy-descriptor.schema.json
+      tests/
+        invalid/          # negative envelope fixtures (MUST fail validation)
       policy/
         decision-rules.schema.json
         quorum-rules.schema.json
@@ -101,7 +109,10 @@ MACP/
         handoff-rules.schema.json
     conformance/
       README.md
+      schema.json         # fixture-format JSON Schema
+      lint_fixtures.py    # internal-consistency linter (CI)
       decision_happy_path.json
+      decision_negative_outcome.json
       decision_reject_paths.json
       proposal_happy_path.json
       proposal_reject_paths.json
@@ -173,6 +184,8 @@ MACP runtimes and clients negotiate protocol compatibility and optional features
 The base capability model supports:
 
 - `sessions.stream` - bidirectional session streams
+- `sessions.list_sessions` - paginated session metadata listing
+- `sessions.watch_sessions` - streaming session lifecycle events
 - `cancellation.cancelSession` - explicit session cancellation
 - `progress.progress` - non-binding progress updates
 - `manifest.getManifest` - runtime/agent manifest discovery
@@ -242,7 +255,7 @@ See `CONTRIBUTING.md` for the release workflow.
 make validate
 ```
 
-Validation checks JSON schemas/examples and compiles all versioned Protobuf definitions if local tooling is available.
+`make validate` meta-validates all JSON Schemas, validates every example and conformance fixture against its schema, asserts the negative envelope fixtures are rejected, lints conformance fixtures for internal consistency, lints and compiles all versioned Protobuf definitions, and verifies the raw-proto packages match the canonical schemas. Run `make help` for individual targets; `make install-tools` installs `ajv-cli`, `protoc`, and `buf`.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -535,7 +535,7 @@ sequenceDiagram
   participant A as Agent
 
   I->>K: CancelSession(session_id)
-  Note over K: Session transitions OPEN -> EXPIRED<br/>History remains append-only
+  Note over K: Session transitions OPEN -> CANCELLED<br/>History remains append-only
 
   K-->>A: Optional CancelNotice(session_id)
 

--- a/docs/determinism.md
+++ b/docs/determinism.md
@@ -192,7 +192,7 @@ if (userProfile.riskScore > 50) {
 }
 ```
 
-**Better:** Include necessary context in SessionStart `context` field (base64-encoded)
+**Better:** Bind necessary context at SessionStart — reference it via `context_id` (an opaque identifier the runtime preserves but never interprets) or carry protocol-specific bytes in `extensions`
 
 ### Randomness
 
@@ -250,7 +250,7 @@ For financial transactions, database writes, etc.:
 2. **Verify versions**: macp_version, mode, mode_version, configuration_version match
 3. **Replay messages**: Feed messages to MACP runtime in same order
 4. **Compare state transitions**: OPEN → RESOLVED/EXPIRED must match
-5. **Compare terminal message**: Commitment/SessionEnd must match (if deterministic Mode)
+5. **Compare terminal message**: the terminal `Commitment` (or mode-defined terminal message) must match (if deterministic Mode)
 
 ### Cryptographic Verification (Optional)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -54,3 +54,7 @@ Across the transcripts, the examples demonstrate:
 - policy resolution, governance evaluation, and deterministic commitment decisions (RFC-MACP-0012).
 
 The important property is not the specific business scenario in each example. It is that every bound coordination event exists as a bounded transcript with a start, a lifecycle, and a terminal message.
+
+## Related: conformance fixtures
+
+The examples above are illustrative. For **machine-checked** message sequences with per-message accept/reject expectations — consumed by SDK projection harnesses and the runtime conformance suite — see the canonical fixture pack in [`schemas/conformance/`](../schemas/conformance/README.md). Fixtures exist for every standards-track mode plus the `ext.multi_round.v1` extension mode, and CI validates each fixture against the fixture-format schema and lints it for internal consistency.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -72,7 +72,7 @@ If multiple terminal messages are sent concurrently, the first one accepted into
 
 Two RPCs provide programmatic session lifecycle observation:
 
-- **`ListSessions`** — returns `SessionMetadata` for all known sessions. Use for initial sync. Advertised by `sessions.list_sessions`.
+- **`ListSessions`** — returns a page of `SessionMetadata` (bounded by `page_size`; continue with `page_token` until `next_page_token` is empty). Use for initial sync. Advertised by `sessions.list_sessions`.
 - **`WatchSessions`** — server-streaming RPC that emits `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED, SUSPENDED, RESUMED, CANCELLED) in real time. Advertised by `sessions.watch_sessions`.
 
 Control-planes and UIs typically call `ListSessions` on startup for a snapshot, then subscribe to `WatchSessions` for incremental updates. Events are ephemeral and not replayed.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -88,7 +88,7 @@ Key differences from standards-track modes:
 
 - `ListModes` returns only standards-track modes. Extensions are discoverable through implementation-defined surfaces.
 - `GetManifest` and `Initialize` may include extension identifiers in `supported_modes` to advertise the full runtime capability.
-- Extension modes do not have canonical schemas or RFCs in this repository.
+- Extension modes do not have RFCs in this repository. A widely-implemented extension mode may still ship a canonical payload schema for interoperability: `ext.multi_round.v1` (iterative convergence over opaque contributions) is defined in [`schemas/proto/macp/modes/multi_round/v1/multi_round.proto`](../schemas/proto/macp/modes/multi_round/v1/multi_round.proto), with conformance fixtures under [`schemas/conformance/`](../schemas/conformance/README.md).
 - Runtimes may support dynamic registration, removal, and promotion of extension modes.
 
 See [RFC-MACP-0002 §12](../rfcs/RFC-MACP-0002-modes.md) for normative guidance.
@@ -106,3 +106,5 @@ Example transcripts live under `examples/`:
 - `task-mode-session.json`
 - `handoff-mode-session.json`
 - `quorum-mode-session.json`
+
+Machine-checked per-mode conformance fixtures (happy paths and reject paths, including `ext.multi_round.v1`) live under [`schemas/conformance/`](../schemas/conformance/README.md).

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -35,7 +35,7 @@ A policy descriptor has five required fields:
 Canonical proto: [`schemas/proto/macp/v1/policy.proto`](../schemas/proto/macp/v1/policy.proto)
 JSON Schema: [`schemas/json/macp-policy-descriptor.schema.json`](../schemas/json/macp-policy-descriptor.schema.json)
 
-In the Protobuf wire format, `rules` is `bytes` containing JSON-encoded text. In JSON examples, `rules` is shown as a decoded JSON object for readability.
+In the Protobuf wire format, `rules` is a `string` containing JSON-encoded text. In JSON examples, `rules` is shown as a decoded JSON object for readability.
 
 ## Rule Schemas by Mode
 

--- a/docs/sdk-parity.md
+++ b/docs/sdk-parity.md
@@ -7,7 +7,7 @@ This document defines what MACP SDKs must implement to be considered conformant,
 Every official MACP SDK MUST provide:
 
 ### Transport Layer
-- **MacpClient** — gRPC client implementing all RPCs in `MACPRuntimeService` (currently 22)
+- **MacpClient** — gRPC client implementing all RPCs in `MACPRuntimeService` (currently 24, including `SuspendSession`/`ResumeSession`)
 - **MacpStream** — bidirectional streaming wrapper for `StreamSession`
 - **Authentication** — dev agent (`x-macp-agent-id`) and bearer token modes
 
@@ -63,9 +63,9 @@ Optional features that enhance the SDK but are not required for conformance:
 - **CI enforcement**: `proto-sync` job in each SDK's CI verifies no drift against BSR
 
 ### Conformance Fixture Sync
-- **Source of truth**: `schemas/conformance/` in this RFC repo (copied from Runtime, which is authoritative)
+- **Source of truth**: `schemas/conformance/` in this RFC repo is the only canonical fixture location. Fixture changes land here first, then sync downstream; the runtime vendors byte-identical copies under `tests/conformance/` and its CI byte-compares them against this directory (see `schemas/conformance/README.md`).
 - **Local sync**: `make sync-fixtures` in each SDK
-- **CI enforcement**: `fixture-sync` job verifies fixtures match canonical source
+- **CI enforcement**: `fixture-sync` job verifies fixtures match canonical source; this repo's CI validates every fixture against `schemas/conformance/schema.json` and lints internal consistency (`make conformance-lint`)
 
 ### Adding a New RPC or Mode
 1. Define in RFC repo's proto files

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -44,7 +44,7 @@ Returns a `SessionMetadata` snapshot for a given session, including the session'
 
 ### `ListSessions` / `WatchSessions` (Session Observation)
 
-Programmatic session lifecycle observation. `ListSessions` returns `SessionMetadata` for all known sessions (advertised by `sessions.list_sessions`); `WatchSessions` is a server-streaming RPC emitting `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED) in real time (advertised by `sessions.watch_sessions`). Control-planes and UIs typically call `ListSessions` at startup for a snapshot, then subscribe to `WatchSessions` for incremental updates. Events are ephemeral and not replayed. See [docs/lifecycle.md](lifecycle.md#session-observation).
+Programmatic session lifecycle observation. `ListSessions` returns a page of `SessionMetadata` (bounded by `page_size`, continued via `page_token` / `next_page_token`; advertised by `sessions.list_sessions`); `WatchSessions` is a server-streaming RPC emitting `SessionLifecycleEvent` notifications (CREATED, RESOLVED, EXPIRED, SUSPENDED, RESUMED, CANCELLED) in real time (advertised by `sessions.watch_sessions`). Control-planes and UIs typically page through `ListSessions` at startup for a snapshot, then subscribe to `WatchSessions` for incremental updates. Events are ephemeral and not replayed. See [docs/lifecycle.md](lifecycle.md#session-observation).
 
 ## HTTP
 

--- a/packages/proto-python/pyproject.toml
+++ b/packages/proto-python/pyproject.toml
@@ -24,7 +24,9 @@ dependencies = [
   # protobuf>=7.35 / grpcio>=1.82 at runtime. Bump these together with the
   # generator pin (issue #53 shipped wheels whose declared floors were below
   # what the code could import against).
-  "grpcio>=1.82.0",
+  # grpcio 1.82.0 was yanked from PyPI; 1.82.1 is the fixed re-release and
+  # the floor its gencode enforces.
+  "grpcio>=1.82.1",
   "protobuf>=7.35.0",
 ]
 

--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -21,6 +21,10 @@ first, then sync downstream.
 `schema.json` is the JSON Schema (draft 2020-12) for the fixture format —
 payload-type names are fully-qualified proto names
 (`macp.modes.decision.v1.ProposalPayload`, `macp.v1.CommitmentPayload`).
+Every fixture in this directory is validated against `schema.json` in CI
+(`scripts/validate-json.sh`). Keys starting with `_` (e.g. `_comment`) are
+non-normative annotations allowed at the fixture and message level; harnesses
+MUST ignore them.
 Reject messages should carry `expected_error_code` (asserted by the runtime
 harness). `lint_fixtures.py` checks internal consistency; note that initiator
 participant-list membership is mode-specific (only handoff's delegated model

--- a/schemas/conformance/schema.json
+++ b/schemas/conformance/schema.json
@@ -88,6 +88,12 @@
             "type": "string"
           }
         },
+        "patternProperties": {
+          "^_": {
+            "type": "string",
+            "description": "Non-normative annotation (e.g. _comment). Harnesses MUST ignore keys starting with '_'."
+          }
+        },
         "additionalProperties": false
       }
     },
@@ -115,6 +121,12 @@
     "policy": {
       "type": "object",
       "description": "Optional inline PolicyDefinition registered before SessionStart"
+    }
+  },
+  "patternProperties": {
+    "^_": {
+      "type": "string",
+      "description": "Non-normative annotation (e.g. _comment). Harnesses MUST ignore keys starting with '_'."
     }
   },
   "additionalProperties": false

--- a/schemas/json/tests/invalid/README.md
+++ b/schemas/json/tests/invalid/README.md
@@ -1,0 +1,25 @@
+# Invalid envelope fixtures (negative schema tests)
+
+Each file in this directory is an envelope that MUST be **rejected** by
+`schemas/json/macp-envelope.schema.json`. They are regression tests for the
+schema's structural constraints: if a schema change accidentally loosens a
+constraint, `scripts/validate-json.sh` fails because one of these fixtures
+starts validating.
+
+Each fixture carries a top-level `_invalid_because` annotation stating the
+constraint it violates and the RFC section that defines it. The envelope
+schema permits unknown fields (forward compatibility), so the annotation
+itself never causes the rejection.
+
+| Fixture | Violated constraint |
+|---------|---------------------|
+| `signal_with_session_id.json` | Signals are ambient: `mode` and `session_id` MUST be empty (RFC-MACP-0001 §6) |
+| `session_scoped_empty_session_id.json` | Session-scoped messages MUST carry non-empty `mode` and `session_id` (RFC-MACP-0001 §6) |
+| `payload_and_payload_b64.json` | `payload` and `payload_b64` are mutually exclusive (RFC-MACP-0001 §10) |
+| `missing_payload.json` | Exactly one of `payload` / `payload_b64` is required (RFC-MACP-0001 §10) |
+| `bad_macp_version.json` | `macp_version` MUST be semantic-version formatted |
+| `session_start_missing_versions.json` | SessionStart MUST bind `ttl_ms`, `mode_version`, `configuration_version` (RFC-MACP-0001 §7, RFC-MACP-0003) |
+
+To add a case: drop a new `.json` file here with an `_invalid_because`
+annotation — `validate-json.sh` picks it up automatically and asserts it fails
+envelope validation.

--- a/schemas/json/tests/invalid/bad_macp_version.json
+++ b/schemas/json/tests/invalid/bad_macp_version.json
@@ -1,0 +1,14 @@
+{
+  "_invalid_because": "macp_version MUST be a semantic version string (e.g. '1.0.0'); a 'v' prefix is not part of the canonical mapping.",
+  "macp_version": "v1",
+  "mode": "macp.mode.decision.v1",
+  "message_type": "Commitment",
+  "message_id": "msg-invalid-005",
+  "session_id": "sess-abc123",
+  "sender": "agent://lead",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "commitment_id": "commit-001",
+    "action": "decision.approved"
+  }
+}

--- a/schemas/json/tests/invalid/missing_payload.json
+++ b/schemas/json/tests/invalid/missing_payload.json
@@ -1,0 +1,10 @@
+{
+  "_invalid_because": "Every envelope MUST carry exactly one of 'payload' or 'payload_b64' (RFC-MACP-0001 §10). This envelope carries neither.",
+  "macp_version": "1.0.0",
+  "mode": "macp.mode.decision.v1",
+  "message_type": "Commitment",
+  "message_id": "msg-invalid-004",
+  "session_id": "sess-abc123",
+  "sender": "agent://lead",
+  "timestamp": "2026-07-07T00:00:00Z"
+}

--- a/schemas/json/tests/invalid/payload_and_payload_b64.json
+++ b/schemas/json/tests/invalid/payload_and_payload_b64.json
@@ -1,0 +1,15 @@
+{
+  "_invalid_because": "An envelope carries EITHER a decoded 'payload' OR opaque 'payload_b64' bytes, never both (RFC-MACP-0001 §10). This envelope carries both.",
+  "macp_version": "1.0.0",
+  "mode": "macp.mode.task.v1",
+  "message_type": "Progress",
+  "message_id": "msg-invalid-003",
+  "session_id": "sess-abc123",
+  "sender": "agent://worker",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "progress": 1,
+    "total": 3
+  },
+  "payload_b64": "eyJwcm9ncmVzcyI6IDF9"
+}

--- a/schemas/json/tests/invalid/session_scoped_empty_session_id.json
+++ b/schemas/json/tests/invalid/session_scoped_empty_session_id.json
@@ -1,0 +1,17 @@
+{
+  "_invalid_because": "Session-scoped messages MUST carry a non-empty mode and session_id (RFC-MACP-0001 §6). This SessionStart has both empty.",
+  "macp_version": "1.0.0",
+  "mode": "",
+  "message_type": "SessionStart",
+  "message_id": "msg-invalid-002",
+  "session_id": "",
+  "sender": "agent://initiator",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "intent": "decide deployment",
+    "participants": ["agent://initiator", "agent://peer"],
+    "ttl_ms": 60000,
+    "mode_version": "1.0.0",
+    "configuration_version": "config.default"
+  }
+}

--- a/schemas/json/tests/invalid/session_start_missing_versions.json
+++ b/schemas/json/tests/invalid/session_start_missing_versions.json
@@ -1,0 +1,14 @@
+{
+  "_invalid_because": "SessionStart payloads MUST bind ttl_ms, mode_version, and configuration_version for replay integrity (RFC-MACP-0001 §7, RFC-MACP-0003). This payload omits all three.",
+  "macp_version": "1.0.0",
+  "mode": "macp.mode.quorum.v1",
+  "message_type": "SessionStart",
+  "message_id": "msg-invalid-006",
+  "session_id": "sess-def456",
+  "sender": "agent://coordinator",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "intent": "approve release",
+    "participants": ["agent://a", "agent://b", "agent://c"]
+  }
+}

--- a/schemas/json/tests/invalid/signal_with_session_id.json
+++ b/schemas/json/tests/invalid/signal_with_session_id.json
@@ -1,0 +1,13 @@
+{
+  "_invalid_because": "Signals are ambient-plane messages: mode and session_id MUST be empty (RFC-MACP-0001 §6). This Signal carries a mode and a session_id.",
+  "macp_version": "1.0.0",
+  "mode": "macp.mode.decision.v1",
+  "message_type": "Signal",
+  "message_id": "msg-invalid-001",
+  "session_id": "sess-abc123",
+  "sender": "agent://observer",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "signal_type": "telemetry.heartbeat"
+  }
+}

--- a/scripts/validate-json.sh
+++ b/scripts/validate-json.sh
@@ -18,6 +18,9 @@ AGENT_BOOTSTRAP_SCHEMA="${PROJECT_ROOT}/schemas/json/macp-agent-bootstrap.schema
 EXAMPLES_DIR="${PROJECT_ROOT}/examples/json"
 DISCOVERY_DIR="${PROJECT_ROOT}/examples/discovery"
 TRANSCRIPT_GLOB="${PROJECT_ROOT}/examples/*.json"
+CONFORMANCE_DIR="${PROJECT_ROOT}/schemas/conformance"
+CONFORMANCE_SCHEMA="${CONFORMANCE_DIR}/schema.json"
+INVALID_ENVELOPE_DIR="${PROJECT_ROOT}/schemas/json/tests/invalid"
 
 echo "Validating JSON examples against schemas..."
 echo ""
@@ -212,6 +215,54 @@ print(count)
         echo ""
     fi
 done
+
+# Validate conformance fixtures against the fixture-format schema.
+# lint_fixtures.py checks internal consistency; this checks structural shape.
+if [ -f "${CONFORMANCE_SCHEMA}" ]; then
+    echo "-- Conformance fixtures (${CONFORMANCE_DIR}/*.json) --"
+    echo "Schema: ${CONFORMANCE_SCHEMA}"
+    echo ""
+
+    for fixture_file in "${CONFORMANCE_DIR}"/*.json; do
+        if [ -f "$fixture_file" ] && [ "$(basename "$fixture_file")" != "schema.json" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "Validating: conformance/$(basename "$fixture_file")"
+
+            if ajv validate -s "${CONFORMANCE_SCHEMA}" -d "${fixture_file}" --spec=draft2020 --strict=false; then
+                VALIDATED=$((VALIDATED + 1))
+                echo "  [OK] Valid"
+            else
+                echo "  [X] Invalid"
+                exit 1
+            fi
+            echo ""
+        fi
+    done
+fi
+
+# Negative tests: envelopes that MUST be rejected by the envelope schema.
+# If one of these validates, a schema change has loosened a constraint.
+if [ -d "${INVALID_ENVELOPE_DIR}" ]; then
+    echo "-- Negative envelope tests (${INVALID_ENVELOPE_DIR}/*.json) --"
+    echo "  Each fixture MUST FAIL envelope-schema validation."
+    echo ""
+
+    for invalid_file in "${INVALID_ENVELOPE_DIR}"/*.json; do
+        if [ -f "$invalid_file" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "Validating (expect reject): tests/invalid/$(basename "$invalid_file")"
+
+            if ajv validate -s "${ENVELOPE_SCHEMA}" -d "${invalid_file}" --spec=draft2020 --strict=false >/dev/null 2>&1; then
+                echo "  [X] Fixture unexpectedly PASSED validation — the envelope schema no longer rejects this case"
+                exit 1
+            else
+                VALIDATED=$((VALIDATED + 1))
+                echo "  [OK] Correctly rejected"
+            fi
+            echo ""
+        fi
+    done
+fi
 
 if [ $TOTAL -eq 0 ]; then
     echo "Warning: No JSON example files found"


### PR DESCRIPTION
## Summary

Improves the repo's validation gates and fixes factual drift in the docs, verified against the canonical protos and RFCs. `make validate` was broken before this PR and now passes end-to-end; JSON validation coverage goes from 19 to 38 files.

## Tests / validation

- **Conformance fixtures are now schema-checked.** `scripts/validate-json.sh` validates every `schemas/conformance/*.json` fixture against `schema.json`. Nothing enforced the fixture format before — and it caught a real miss: `handoff_reject_paths.json` carries a `_comment` annotation the schema rejected. `schema.json` now explicitly allows `_`-prefixed string annotation keys at fixture and message level (documented in the conformance README).
- **Negative envelope tests.** New `schemas/json/tests/invalid/` holds six envelopes that MUST be rejected by `macp-envelope.schema.json` (Signal with session_id, both `payload` and `payload_b64`, missing version bindings, etc. — each annotated with the violated RFC constraint). `validate-json.sh` asserts each one fails, so an accidental loosening of the envelope schema now breaks CI instead of passing silently.
- **`make validate` fixed.** It still invoked `check-python-stubs` / `check-go-stubs`, whose scripts were deleted in 56a6354 — so the documented entrypoint has been broken since. Removed the dead targets and added `conformance-lint` (runs `lint_fixtures.py`, matching the CI job) to `make validate`, so the local gate now mirrors CI.

## Docs drift fixes (each verified against source)

| Doc | Was | Is |
|---|---|---|
| `docs/architecture.md` | Cancel diagram: `OPEN -> EXPIRED` | `OPEN -> CANCELLED` (`SESSION_STATE_CANCELLED`) |
| `docs/determinism.md` | terminal `SessionEnd`; SessionStart `context` (base64) | no such message/field — `Commitment`; `context_id` / `extensions` |
| `docs/transports.md`, `docs/lifecycle.md` | `ListSessions` returns *all* sessions; 3 lifecycle events | paginated (`page_size`/`page_token`); all 6 events incl. SUSPENDED/RESUMED/CANCELLED |
| `docs/policy.md` | `rules` is `bytes` | `string` (policy.proto) |
| `docs/sdk-parity.md` | 22 RPCs; fixtures "copied from Runtime, which is authoritative" | 24 RPCs; this repo is the canonical fixture source (per PR #49) |
| `README.md`, `CLAUDE.md` | missing `multi_round` protos, conformance pack, newer JSON schemas, `sessions.list_sessions`/`watch_sessions` capabilities; stale "pre-generated stubs" package descriptions; stale validation commands | brought in line with the tree, capability model, and Makefile |
| `docs/modes.md`, `docs/examples.md` | "extension modes have no canonical schemas here" | documents `ext.multi_round.v1` canonical proto + links the conformance fixture pack |

## Validation

- `make validate` passes end-to-end (json-schema meta-validation, 38/38 JSON files incl. 13 conformance fixtures and 6 negative tests, conformance lint, buf lint, protoc compile, proto-package sync).