### PR TITLE
test(conformance): add negative-outcome fixtures for proposal/task/handoff/quorum

### DIFF
--- a/schemas/conformance/handoff_negative_outcome.json
+++ b/schemas/conformance/handoff_negative_outcome.json
@@ -1,0 +1,61 @@
+{
+  "mode": "macp.mode.handoff.v1",
+  "initiator": "agent://owner",
+  "participants": [
+    "agent://owner",
+    "agent://target"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy_version": "",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://owner",
+      "message_type": "HandoffOffer",
+      "payload_type": "macp.modes.handoff.v1.HandoffOfferPayload",
+      "payload": {
+        "handoff_id": "h1",
+        "target_participant": "agent://target",
+        "scope": "support",
+        "reason": "escalate"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://target",
+      "message_type": "HandoffDecline",
+      "payload_type": "macp.modes.handoff.v1.HandoffDeclinePayload",
+      "payload": {
+        "handoff_id": "h1",
+        "declined_by": "agent://target",
+        "reason": "out of scope"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://owner",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "action": "handoff.declined",
+        "authority_scope": "test",
+        "reason": "target declined",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": false
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "handoff.declined",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  }
+}

--- a/schemas/conformance/proposal_negative_outcome.json
+++ b/schemas/conformance/proposal_negative_outcome.json
@@ -1,0 +1,62 @@
+{
+  "mode": "macp.mode.proposal.v1",
+  "initiator": "agent://buyer",
+  "participants": [
+    "agent://buyer",
+    "agent://seller"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy_version": "",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://seller",
+      "message_type": "Proposal",
+      "payload_type": "macp.modes.proposal.v1.ProposalPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "title": "offer",
+        "summary": "terms",
+        "details": [],
+        "tags": []
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://buyer",
+      "message_type": "Reject",
+      "payload_type": "macp.modes.proposal.v1.RejectPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "reason": "terms unacceptable",
+        "terminal": true
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://buyer",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "action": "proposal.rejected",
+        "authority_scope": "test",
+        "reason": "terminal rejection",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": false
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "proposal.rejected",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  }
+}

--- a/schemas/conformance/quorum_negative_outcome.json
+++ b/schemas/conformance/quorum_negative_outcome.json
@@ -1,0 +1,72 @@
+{
+  "mode": "macp.mode.quorum.v1",
+  "initiator": "agent://coordinator",
+  "participants": [
+    "agent://alice",
+    "agent://bob",
+    "agent://carol"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy_version": "",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://coordinator",
+      "message_type": "ApprovalRequest",
+      "payload_type": "macp.modes.quorum.v1.ApprovalRequestPayload",
+      "payload": {
+        "request_id": "r1",
+        "action": "deploy",
+        "summary": "Deploy v2",
+        "details": [],
+        "required_approvals": 2
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://alice",
+      "message_type": "Reject",
+      "payload_type": "macp.modes.quorum.v1.RejectPayload",
+      "payload": {
+        "request_id": "r1",
+        "reason": "not ready"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://bob",
+      "message_type": "Abstain",
+      "payload_type": "macp.modes.quorum.v1.AbstainPayload",
+      "payload": {
+        "request_id": "r1",
+        "reason": "no opinion"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://coordinator",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "action": "quorum.rejected",
+        "authority_scope": "test",
+        "reason": "threshold unreachable",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": false
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "quorum.rejected",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  }
+}

--- a/schemas/conformance/task_negative_outcome.json
+++ b/schemas/conformance/task_negative_outcome.json
@@ -1,0 +1,76 @@
+{
+  "mode": "macp.mode.task.v1",
+  "initiator": "agent://planner",
+  "participants": [
+    "agent://planner",
+    "agent://worker"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy_version": "",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://planner",
+      "message_type": "TaskRequest",
+      "payload_type": "macp.modes.task.v1.TaskRequestPayload",
+      "payload": {
+        "task_id": "t1",
+        "title": "Build",
+        "instructions": "Do it",
+        "requested_assignee": "agent://worker",
+        "input": [],
+        "deadline_unix_ms": 0
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://worker",
+      "message_type": "TaskAccept",
+      "payload_type": "macp.modes.task.v1.TaskAcceptPayload",
+      "payload": {
+        "task_id": "t1",
+        "assignee": "agent://worker",
+        "reason": "ready"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://worker",
+      "message_type": "TaskFail",
+      "payload_type": "macp.modes.task.v1.TaskFailPayload",
+      "payload": {
+        "task_id": "t1",
+        "assignee": "agent://worker",
+        "error_code": "BUILD_FAILED",
+        "reason": "compilation error",
+        "retryable": false
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://planner",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "action": "task.failed",
+        "authority_scope": "test",
+        "reason": "assignee reported failure",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.default",
+        "configuration_version": "cfg-1",
+        "outcome_positive": false
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "task.failed",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  }
+}


### PR DESCRIPTION
## Why

Only `decision` had a `*_negative_outcome` conformance fixture. The four **provisional** standards-track modes (proposal/task/handoff/quorum) each have a normatively-mandated negative terminal outcome (`outcome_positive` MUST be set explicitly; negative outcomes are permitted), but **no portable fixture exercised those paths** — so a second implementer using the conformance pack wasn't forced to get them right. This closes that gap, part of hardening the "at least one interoperable implementation" evidence for promoting those modes to Permanent (RFC-MACP-0002 §11).

## What

One `*_negative_outcome.json` per mode, each driving the mode's actual negative-commit eligibility rule to a `Resolved` commitment with `outcome_positive: false`:

| Mode | Sequence | Terminal |
|---|---|---|
| proposal | `Proposal → Reject(terminal=true) → Commitment` | `proposal.rejected` |
| task | `TaskRequest → TaskAccept → TaskFail → Commitment` | `task.failed` |
| handoff | `HandoffOffer → HandoffDecline → Commitment` | `handoff.declined` |
| quorum | `ApprovalRequest(req=2) → Reject → Abstain → Commitment` (threshold unreachable) | `quorum.rejected` |

These also exercise the `Reject` (proposal + quorum), `Abstain`, `TaskFail`, and `HandoffDecline` message types — none of which appeared in any prior fixture.

## Verification

- `python3 schemas/conformance/lint_fixtures.py` — 17 fixtures, all internally consistent.
- `scripts/validate-json.sh` — 42/42 JSON files validate against `schema.json`.
- The macp-runtime reference implementation accepts each sequence and produces the asserted negative resolution (see companion runtime PR); replay-equivalence holds. Verified against these canonical files directly via the runtime's conformance oracle.

Downstream sync (runtime vendored copies + SDKs) follows in their repos.