### PR TITLE
ci: hub → consumer proto-released dispatch + App-token website notify

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -12,8 +12,19 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      # Zero-PAT: mint a short-lived macp-deps-bot installation token scoped to
+      # the website repo instead of the WEBSITE_SYNC_TOKEN PAT.
+      - name: Mint GitHub App token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MACP_BOT_APP_ID }}
+          private-key: ${{ secrets.MACP_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: website
+
       - uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.WEBSITE_SYNC_TOKEN }}
+          token: ${{ steps.app.outputs.token }}
           repository: multiagentcoordinationprotocol/website
           event-type: docs-updated

--- a/.github/workflows/publish-proto-packages.yml
+++ b/.github/workflows/publish-proto-packages.yml
@@ -280,3 +280,45 @@ jobs:
             --source "https://nuget.pkg.github.com/multiagentcoordinationprotocol/index.json" \
             --api-key "${{ secrets.GITHUB_TOKEN }}"
 
+  # ── Notify in-org proto consumers (event-driven bump) ───────────────
+  # After the ecosystems this org consumes have published, dispatch
+  # proto-released {version, ecosystem} to each of the 4 in-org consumers.
+  # Their bump-proto.yml (macp-ci@v1 → bump-consume.yml) opens a bump PR and
+  # arms auto-merge. Uses a short-lived macp-deps-bot App token — no PATs.
+  dispatch-consumers:
+    name: Dispatch proto-released to consumers
+    runs-on: ubuntu-latest
+    needs: [extract-version, publish-npm, publish-pypi, publish-rust]
+    if: needs.extract-version.outputs.dry_run != 'true'
+    steps:
+      - name: Mint GitHub App token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.MACP_BOT_APP_ID }}
+          private-key: ${{ secrets.MACP_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            macp-runtime
+            macp-sdk-python
+            macp-sdk-typescript
+            macp-control-plane
+
+      - name: Dispatch proto-released
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          OWNER: ${{ github.repository_owner }}
+          VERSION: ${{ needs.extract-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          dispatch() {  # $1=repo  $2=ecosystem
+            jq -nc --arg v "$VERSION" --arg e "$2" \
+              '{event_type:"proto-released",client_payload:{version:$v,ecosystem:$e}}' \
+              | gh api -X POST "repos/$OWNER/$1/dispatches" --input -
+            echo "dispatched proto-released {version=$VERSION, ecosystem=$2} -> $1"
+          }
+          dispatch macp-runtime        cargo
+          dispatch macp-sdk-python     pip
+          dispatch macp-sdk-typescript npm
+          dispatch macp-control-plane  npm
+


### PR DESCRIPTION
**Held for review** (Part D §6/§7 of the delivery plan) — changes publish-time behavior.

## What
1. `publish-proto-packages.yml` gains a `dispatch-consumers` job: after the npm/PyPI/crates jobs publish (skipped on dry-run), it mints a **macp-deps-bot** App token scoped to the 4 in-org consumers and POSTs `repository_dispatch: proto-released {version, ecosystem}`:
   - cargo → `macp-runtime`
   - pip → `macp-sdk-python`
   - npm → `macp-sdk-typescript`
   - npm → `macp-control-plane`
   Each consumer's `bump-proto.yml` (`macp-ci@v1`) opens the bump PR and arms auto-merge unless breaking.
2. `notify-website.yml`: swaps the `WEBSITE_SYNC_TOKEN` PAT for a scoped App token (**zero-PAT**).

## Notes
- Org secrets `MACP_BOT_APP_ID` / `MACP_BOT_PRIVATE_KEY` are already set.
- Do **not** delete `WEBSITE_SYNC_TOKEN` until every `notify-*` workflow across the org is swapped (tracked separately).
- Reusable workflows live in `multiagentcoordinationprotocol/macp-ci@v1`; see its `DELIVERY-STANDARD.md`.
- Validated with actionlint.