### PR TITLE
ci: delivery standardization — auto-merge + Dependabot (hub)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Keeps the SHA-pinned / tagged GitHub Actions across all workflows current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,8 @@
+name: auto-merge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  call:
+    uses: multiagentcoordinationprotocol/macp-ci/.github/workflows/auto-merge.yml@v1


### PR DESCRIPTION
Adds the **auto-merge** caller (`macp-ci@v1`) and a **Dependabot** config (github-actions, patch/minor grouped) to the proto/spec hub. Part of the org-wide delivery/CI-CD standardization.