### PR TITLE
ci: SHA-pin peter-evans/repository-dispatch (v4.0.1)

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -23,7 +23,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: website
 
-      - uses: peter-evans/repository-dispatch@v3
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app.outputs.token }}
           repository: multiagentcoordinationprotocol/website


### PR DESCRIPTION
Pins the third-party `peter-evans/repository-dispatch` action to its v4.0.1 commit SHA (delivery-standard convention: SHA-pin third-party actions).