### PR TITLE
ci: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Push to BSR
         if: github.ref == 'refs/heads/main'
-        uses: bufbuild/buf-push-action@v1
+        uses: bufbuild/buf-push-action@a654ff18effe4641ebea4a4ce242c49800728459 # v1
         with:
           input: schemas/proto
           buf_token: ${{ secrets.BUF_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install buf
-        uses: bufbuild/buf-setup-action@v1
+        uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-proto-packages.yml
+++ b/.github/workflows/publish-proto-packages.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       - uses: actions/setup-go@v6
         with:
           go-version: '1.23'
@@ -183,7 +183,7 @@ jobs:
     needs: [extract-version]
     steps:
       - uses: actions/checkout@v7
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -214,7 +214,7 @@ jobs:
     needs: [extract-version, publish-java]
     steps:
       - uses: actions/checkout@v7
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -258,7 +258,7 @@ jobs:
     needs: [extract-version]
     steps:
       - uses: actions/checkout@v7
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '8.0.x'


### PR DESCRIPTION
SHA-pins all third-party GitHub Actions (docker/*, bufbuild/*, aquasecurity/trivy, appleboy/ssh, peter-evans/*) to commit SHAs with a `# vTag` comment, per the delivery standard. First-party `actions/*` stay on major tags. Dependabot keeps the SHAs current (updates both SHA + comment). No behavior change — pinned to the versions already on main.