### PR TITLE
ci(dependabot): switch to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 5
     groups:
       actions:


### PR DESCRIPTION
Changes all `interval: weekly` -> `interval: monthly` (was 1 updater(s)). Cuts version-update PR volume ~4x; security updates still fire immediately. Combined with grouping, each run is a few PRs, once a month.