### PR TITLE
docs: repair the registry-count enumeration and dead schemas/examples links

### DIFF
--- a/docs/discovery.md
+++ b/docs/discovery.md
@@ -15,7 +15,7 @@ Each MACP component publishes a manifest describing:
 - supported coordination modes
 - transport endpoints
 
-The manifest JSON Schema is at [`schemas/json/macp-agent-manifest.schema.json`](../schemas/json/macp-agent-manifest.schema.json). A full example is available at [`examples/discovery/agent_manifest.json`](../examples/discovery/agent_manifest.json).
+The manifest JSON Schema is at [`schemas/json/macp-agent-manifest.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-agent-manifest.schema.json). A full example is available at [`examples/discovery/agent_manifest.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/agent_manifest.json).
 
 ## Well-known Discovery
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -8,13 +8,13 @@ This repository includes illustrative transcripts for each standards-track mode 
 
 | File | Mode | What it shows |
 |------|------|---------------|
-| [`examples/decision-mode-session.json`](../examples/decision-mode-session.json) | `macp.mode.decision.v1` | initialization, `SessionStart`, proposal, evaluations, objection, votes, and terminal `Commitment` |
-| [`examples/proposal-mode-session.json`](../examples/proposal-mode-session.json) | `macp.mode.proposal.v1` | offer, counteroffer, dual acceptance, and bound agreement |
-| [`examples/task-mode-session.json`](../examples/task-mode-session.json) | `macp.mode.task.v1` | bounded delegation, progress, completion, and bound task outcome |
-| [`examples/handoff-mode-session.json`](../examples/handoff-mode-session.json) | `macp.mode.handoff.v1` | responsibility transfer with context handoff and acceptance |
-| [`examples/quorum-mode-session.json`](../examples/quorum-mode-session.json) | `macp.mode.quorum.v1` | threshold approval leading to a final commitment |
-| [`examples/policy-decision-session.json`](../examples/policy-decision-session.json) | `macp.mode.decision.v1` | policy-governed Decision Mode with supermajority voting, quorum, and critical-severity veto (RFC-MACP-0012) |
-| [`examples/policy-registration-exchange.json`](../examples/policy-registration-exchange.json) | N/A (gRPC exchange) | dynamic policy registration request and response (RFC-MACP-0012 Section 7) |
+| [`examples/decision-mode-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/decision-mode-session.json) | `macp.mode.decision.v1` | initialization, `SessionStart`, proposal, evaluations, objection, votes, and terminal `Commitment` |
+| [`examples/proposal-mode-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/proposal-mode-session.json) | `macp.mode.proposal.v1` | offer, counteroffer, dual acceptance, and bound agreement |
+| [`examples/task-mode-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/task-mode-session.json) | `macp.mode.task.v1` | bounded delegation, progress, completion, and bound task outcome |
+| [`examples/handoff-mode-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/handoff-mode-session.json) | `macp.mode.handoff.v1` | responsibility transfer with context handoff and acceptance |
+| [`examples/quorum-mode-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/quorum-mode-session.json) | `macp.mode.quorum.v1` | threshold approval leading to a final commitment |
+| [`examples/policy-decision-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/policy-decision-session.json) | `macp.mode.decision.v1` | policy-governed Decision Mode with supermajority voting, quorum, and critical-severity veto (RFC-MACP-0012) |
+| [`examples/policy-registration-exchange.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/policy-registration-exchange.json) | N/A (gRPC exchange) | dynamic policy registration request and response (RFC-MACP-0012 Section 7) |
 
 ## Discovery, lifecycle, and runtime examples
 
@@ -22,13 +22,13 @@ Single-document examples that exercise non-transcript schemas:
 
 | File | Schema | What it shows |
 |------|--------|---------------|
-| [`examples/discovery/agent_manifest.json`](../examples/discovery/agent_manifest.json) | [`macp-agent-manifest.schema.json`](../schemas/json/macp-agent-manifest.schema.json) | agent identity, supported modes, transport endpoints |
-| [`examples/discovery/mode_descriptor.json`](../examples/discovery/mode_descriptor.json) | [`macp-mode-descriptor.schema.json`](../schemas/json/macp-mode-descriptor.schema.json) | mode advertisement with message types and schema URIs |
-| [`examples/discovery/policy_descriptor.json`](../examples/discovery/policy_descriptor.json) | [`macp-policy-descriptor.schema.json`](../schemas/json/macp-policy-descriptor.schema.json) | governance policy advertisement (RFC-MACP-0012) |
-| [`examples/discovery/session_metadata.json`](../examples/discovery/session_metadata.json) | [`macp-session-metadata.schema.json`](../schemas/json/macp-session-metadata.schema.json) | `SessionMetadata` returned by `GetSession` |
-| [`examples/discovery/session_lifecycle_event.json`](../examples/discovery/session_lifecycle_event.json) | [`macp-session-lifecycle-event.schema.json`](../schemas/json/macp-session-lifecycle-event.schema.json) | `SessionLifecycleEvent` emitted by `WatchSessions` |
-| [`examples/discovery/run_descriptor.json`](../examples/discovery/run_descriptor.json) | [`macp-run-descriptor.schema.json`](../schemas/json/macp-run-descriptor.schema.json) | scenario-agnostic run descriptor for a control-plane `POST /runs` |
-| [`examples/discovery/agent_bootstrap.json`](../examples/discovery/agent_bootstrap.json) | [`macp-agent-bootstrap.schema.json`](../schemas/json/macp-agent-bootstrap.schema.json) | bootstrap payload written to `MACP_BOOTSTRAP_FILE` before the initiator agent starts |
+| [`examples/discovery/agent_manifest.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/agent_manifest.json) | [`macp-agent-manifest.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-agent-manifest.schema.json) | agent identity, supported modes, transport endpoints |
+| [`examples/discovery/mode_descriptor.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/mode_descriptor.json) | [`macp-mode-descriptor.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-mode-descriptor.schema.json) | mode advertisement with message types and schema URIs |
+| [`examples/discovery/policy_descriptor.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/policy_descriptor.json) | [`macp-policy-descriptor.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-policy-descriptor.schema.json) | governance policy advertisement (RFC-MACP-0012) |
+| [`examples/discovery/session_metadata.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/session_metadata.json) | [`macp-session-metadata.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-session-metadata.schema.json) | `SessionMetadata` returned by `GetSession` |
+| [`examples/discovery/session_lifecycle_event.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/session_lifecycle_event.json) | [`macp-session-lifecycle-event.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-session-lifecycle-event.schema.json) | `SessionLifecycleEvent` emitted by `WatchSessions` |
+| [`examples/discovery/run_descriptor.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/run_descriptor.json) | [`macp-run-descriptor.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-run-descriptor.schema.json) | scenario-agnostic run descriptor for a control-plane `POST /runs` |
+| [`examples/discovery/agent_bootstrap.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/discovery/agent_bootstrap.json) | [`macp-agent-bootstrap.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-agent-bootstrap.schema.json) | bootstrap payload written to `MACP_BOOTSTRAP_FILE` before the initiator agent starts |
 
 ## Example shape
 
@@ -57,4 +57,4 @@ The important property is not the specific business scenario in each example. It
 
 ## Related: conformance fixtures
 
-The examples above are illustrative. For **machine-checked** message sequences with per-message accept/reject expectations — consumed by SDK projection harnesses and the runtime conformance suite — see the canonical fixture pack in [`schemas/conformance/`](../schemas/conformance/README.md). Fixtures exist for every standards-track mode plus the `ext.multi_round.v1` extension mode, and CI validates each fixture against the fixture-format schema and lints it for internal consistency.
+The examples above are illustrative. For **machine-checked** message sequences with per-message accept/reject expectations — consumed by SDK projection harnesses and the runtime conformance suite — see the canonical fixture pack in [`schemas/conformance/`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/conformance/README.md). Fixtures exist for every standards-track mode plus the `ext.multi_round.v1` extension mode, and CI validates each fixture against the fixture-format schema and lints it for internal consistency.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -88,7 +88,7 @@ Key differences from standards-track modes:
 
 - `ListModes` returns only standards-track modes. Extensions are discoverable through implementation-defined surfaces.
 - `GetManifest` and `Initialize` may include extension identifiers in `supported_modes` to advertise the full runtime capability.
-- Extension modes do not have RFCs in this repository. A widely-implemented extension mode may still ship a canonical payload schema for interoperability: `ext.multi_round.v1` (iterative convergence over opaque contributions) is defined in [`schemas/proto/macp/modes/multi_round/v1/multi_round.proto`](../schemas/proto/macp/modes/multi_round/v1/multi_round.proto), with conformance fixtures under [`schemas/conformance/`](../schemas/conformance/README.md).
+- Extension modes do not have RFCs in this repository. A widely-implemented extension mode may still ship a canonical payload schema for interoperability: `ext.multi_round.v1` (iterative convergence over opaque contributions) is defined in [`schemas/proto/macp/modes/multi_round/v1/multi_round.proto`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/proto/macp/modes/multi_round/v1/multi_round.proto), with conformance fixtures under [`schemas/conformance/`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/conformance/README.md).
 - Runtimes may support dynamic registration, removal, and promotion of extension modes.
 
 See [RFC-MACP-0002 §12](../rfcs/RFC-MACP-0002-modes.md) for normative guidance.
@@ -107,4 +107,4 @@ Example transcripts live under `examples/`:
 - `handoff-mode-session.json`
 - `quorum-mode-session.json`
 
-Machine-checked per-mode conformance fixtures (happy paths and reject paths, including `ext.multi_round.v1`) live under [`schemas/conformance/`](../schemas/conformance/README.md).
+Machine-checked per-mode conformance fixtures (happy paths and reject paths, including `ext.multi_round.v1`) live under [`schemas/conformance/`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/conformance/README.md).

--- a/docs/policy.md
+++ b/docs/policy.md
@@ -32,8 +32,8 @@ A policy descriptor has five required fields:
 | `rules` | object | Mode-specific governance rules (see Rule Schemas) |
 | `schema_version` | uint32 | Version of the rule schema used (`1` or `2`; version `2` adds Decision Mode decline-gating, additive) |
 
-Canonical proto: [`schemas/proto/macp/v1/policy.proto`](../schemas/proto/macp/v1/policy.proto)
-JSON Schema: [`schemas/json/macp-policy-descriptor.schema.json`](../schemas/json/macp-policy-descriptor.schema.json)
+Canonical proto: [`schemas/proto/macp/v1/policy.proto`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/proto/macp/v1/policy.proto)
+JSON Schema: [`schemas/json/macp-policy-descriptor.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/macp-policy-descriptor.schema.json)
 
 In the Protobuf wire format, `rules` is a `string` containing JSON-encoded text. In JSON examples, `rules` is shown as a decoded JSON object for readability.
 
@@ -43,11 +43,11 @@ Each standard mode defines a normative JSON Schema for its governance rules:
 
 | Mode | Rule Schema | Key Parameters |
 |------|-------------|----------------|
-| Decision | [`decision-rules.schema.json`](../schemas/json/policy/decision-rules.schema.json) | Voting algorithm, quorum, objection handling, evaluation constraints, commitment authority |
-| Quorum | [`quorum-rules.schema.json`](../schemas/json/policy/quorum-rules.schema.json) | Threshold override, abstention handling, commitment authority |
-| Proposal | [`proposal-rules.schema.json`](../schemas/json/policy/proposal-rules.schema.json) | Acceptance criterion, max negotiation rounds, rejection behavior |
-| Task | [`task-rules.schema.json`](../schemas/json/policy/task-rules.schema.json) | Reassignment on reject, output requirement, commitment authority |
-| Handoff | [`handoff-rules.schema.json`](../schemas/json/policy/handoff-rules.schema.json) | Implicit accept timeout, commitment authority |
+| Decision | [`decision-rules.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/policy/decision-rules.schema.json) | Voting algorithm, quorum, objection handling, evaluation constraints, commitment authority |
+| Quorum | [`quorum-rules.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/policy/quorum-rules.schema.json) | Threshold override, abstention handling, commitment authority |
+| Proposal | [`proposal-rules.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/policy/proposal-rules.schema.json) | Acceptance criterion, max negotiation rounds, rejection behavior |
+| Task | [`task-rules.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/policy/task-rules.schema.json) | Reassignment on reject, output requirement, commitment authority |
+| Handoff | [`handoff-rules.schema.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/json/policy/handoff-rules.schema.json) | Implicit accept timeout, commitment authority |
 
 Decision Mode supports six voting algorithms: `none`, `majority`, `supermajority`, `unanimous`, `weighted`, and `plurality`. See [RFC-MACP-0012 Section 4.1](../rfcs/RFC-MACP-0012-policy.md) for full details.
 
@@ -97,7 +97,7 @@ Policies are managed through five gRPC RPCs on `MACPRuntimeService`:
 
 Registration constraints: `policy.default` cannot be registered or unregistered; `policy_id` must be unique; `rules` must validate against the target mode's rule schema.
 
-Canonical proto definitions: [`schemas/proto/macp/v1/policy.proto`](../schemas/proto/macp/v1/policy.proto)
+Canonical proto definitions: [`schemas/proto/macp/v1/policy.proto`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/proto/macp/v1/policy.proto)
 
 ## Replay Invariant
 
@@ -105,8 +105,8 @@ The resolved `PolicyDescriptor` MUST be persisted as part of the session snapsho
 
 ## Examples
 
-- [`examples/policy-decision-session.json`](../examples/policy-decision-session.json) — Decision Mode session governed by a supermajority voting policy with quorum and critical-severity veto
-- [`examples/policy-registration-exchange.json`](../examples/policy-registration-exchange.json) — Dynamic policy registration request and response via gRPC
+- [`examples/policy-decision-session.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/policy-decision-session.json) — Decision Mode session governed by a supermajority voting policy with quorum and critical-severity veto
+- [`examples/policy-registration-exchange.json`](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/examples/policy-registration-exchange.json) — Dynamic policy registration request and response via gRPC
 
 ## Error Codes
 

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -2,7 +2,7 @@
 # MACP Transport Guide
 
 > **Status:** Non-normative (explanatory). In case of conflict, the referenced RFC is authoritative.
-> **Reference:** [RFC-MACP-0006](../rfcs/RFC-MACP-0006-transport-bindings.md) | [registries/transports.md](../registries/transports.md) | [core.proto](../schemas/proto/macp/v1/core.proto)
+> **Reference:** [RFC-MACP-0006](../rfcs/RFC-MACP-0006-transport-bindings.md) | [registries/transports.md](../registries/transports.md) | [core.proto](https://github.com/multiagentcoordinationprotocol/multiagentcoordinationprotocol/blob/main/schemas/proto/macp/v1/core.proto)
 
 MACP supports multiple transport layers depending on deployment architecture.
 

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -18,6 +18,6 @@ The MACP standard is intentionally split.
 
 ### Companion Content
 
-- **`registries/`** - initial registry definitions for capabilities, error codes, media types, transports, and standard mode identifiers
+- **`registries/`** - registry definitions for capabilities, error codes, media types, modes, transports, and more
 - **`schemas/`** - canonical Protobuf definitions and human-friendly entrypoints for Core and standard modes
 - **`examples/`** - discovery examples and one transcript for each standard mode in the main repo


### PR DESCRIPTION
## Summary

Fixes #68. Fixes #69.

**#68** — `rfcs/README.md:21` enumerated 5 of 7 registries (missing `policies.md`, `commitment-hash.md`), and this file syncs live into the website's `/spec` page. Reworded to an open-ended hedge instead of completing the list to 7 — the same fix website already applied to the equivalent strings in website#39, for the same reason: a closed enumeration with nothing prompting an update goes stale every time a registry is added.

**#69** — `docs/policy.md` had 10 relative `../schemas/` and `../examples/` links that resolve fine on GitHub but 404 on the published website, because `sync-content.sh` only syncs `docs/`, `rfcs/`, `registries/`, and the runtime/control-plane/SDK repos — `schemas/` and `examples/` are never synced, so there's no website route for those targets to rewrite to.

Per the issue's own suggestion to check for the same pattern elsewhere, a repo-wide grep found the identical dead-link pattern in `docs/examples.md`, `docs/transports.md`, `docs/discovery.md`, and `docs/modes.md` too (23 more links, beyond the 10 the issue named). Fixed all of them the same way: every `../schemas/...` and `../examples/...` link now points at a stable GitHub blob URL, which works from both this repo and the synced website copy. `rfcs/` and `registries/` relative links (which the website *does* sync) were left untouched.

Docs-only change; no schema, RFC, or code touched.

## Test plan

- [x] `grep -rnE '\]\(\.\./(schemas|examples)/' docs/` now returns nothing.
- [x] Spot-checked 3 of the new GitHub blob URLs (`schemas/proto/macp/v1/policy.proto`, `examples/policy-decision-session.json`, `schemas/conformance/README.md`) — all return HTTP 200.
- [x] Confirmed `rfcs/` and `registries/` relative links were untouched by the sed pass.

https://claude.ai/code/session_0162r7372Yd9ycb6Q2xh7cLF