### PR TITLE
ci: assert RFC/registry/fixture indexes stay in sync with disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,12 @@ jobs:
           echo "Checking canonical commitment-hash vectors..."
           python3 scripts/check-cmt-hash-vectors.py
 
+      - name: Check index sync (RFCs, registries, fixtures)
+        run: |
+          echo "Checking hand-maintained indexes against files on disk..."
+          chmod +x scripts/check-indexes.sh
+          ./scripts/check-indexes.sh
+
       - name: Install protoc
         run: |
           sudo apt-get update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Breaking changes require:
 
 ## Registry Additions
 
-To add an entry to a registry (capabilities, error codes, media types, modes, or transports), submit a PR that adds a row to the relevant table in `registries/`. Each entry MUST include a `Status` value (see `registries/README.md` for valid statuses). New identifiers MUST NOT conflict with existing entries.
+To add an entry to a registry (capabilities, error codes, media types, modes, or transports), submit a PR that adds a row to the relevant table in `registries/`. Each entry MUST include a `Status` value (see `registries/README.md` for valid statuses). New identifiers MUST NOT conflict with existing entries. A brand-new registry *file* must also be added to `registries/README.md` and `README.md`'s repo tree — `make check-indexes` enforces this.
 
 ## RFC Proposals
 
@@ -44,7 +44,8 @@ To propose a new RFC:
 
 1. Open an issue using the [RFC proposal template](.github/ISSUE_TEMPLATE/rfc_proposal.yml).
 2. After discussion, create `rfcs/RFC-MACP-XXXX-<topic>.md` (sequential numbering) following the structure of existing RFCs.
-3. Submit a PR referencing the issue; RFCs are accepted through community consensus.
+3. Add the new file to every index that enumerates RFCs — `README.md`'s repo tree, `rfcs/README.md`, `rfcs/RFC-MACP-0001.md`, and this file's Normative RFCs list. `make check-indexes` verifies this and names anything you missed.
+4. Submit a PR referencing the issue; RFCs are accepted through community consensus.
 
 ## Technical Requirements
 
@@ -52,6 +53,7 @@ To propose a new RFC:
 - JSON examples MUST validate against the JSON Schema.
 - Backward compatibility MUST be addressed explicitly.
 - Mode extensions MUST NOT violate MACP Core invariants.
+- Index lists MUST stay in sync with the files on disk (`make check-indexes`).
 
 ## Proto Package Publishing
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help validate validate-all proto-lint proto-compile proto-gen-all json-validate json-schema-validate \
-	conformance-lint cmt-hash-vectors clean install-tools \
+	conformance-lint cmt-hash-vectors check-indexes clean install-tools \
 	gen-go gen-python gen-java gen-kotlin gen-csharp gen-js sync-protos check-proto-sync
 
 PROTO_SRC := schemas/proto
@@ -18,6 +18,7 @@ help:
 	@echo "  make json-validate         Validate JSON examples against schema"
 	@echo "  make conformance-lint      Lint conformance fixtures (internal consistency)"
 	@echo "  make cmt-hash-vectors      Check canonical commitment-hash vectors (RFC-MACP-0013)"
+	@echo "  make check-indexes         Check RFC/registry/fixture indexes match files on disk"
 	@echo "  make proto-lint            Lint Protocol Buffer schemas"
 	@echo "  make proto-compile         Compile Protocol Buffer schemas (validation)"
 	@echo ""
@@ -40,7 +41,7 @@ help:
 	@echo ""
 
 # Validate everything
-validate: json-schema-validate json-validate conformance-lint cmt-hash-vectors proto-lint proto-compile check-proto-sync
+validate: json-schema-validate json-validate conformance-lint cmt-hash-vectors check-indexes proto-lint proto-compile check-proto-sync
 	@echo "✓ All validations passed"
 
 validate-all: validate proto-gen-all
@@ -65,6 +66,11 @@ conformance-lint:
 cmt-hash-vectors:
 	@echo "Checking commitment-hash vectors..."
 	@python3 scripts/check-cmt-hash-vectors.py
+
+# Check the hand-maintained RFC/registry/fixture indexes against files on disk
+check-indexes:
+	@echo "Checking indexes..."
+	@./scripts/check-indexes.sh
 
 # Lint protobuf files with buf
 proto-lint:

--- a/scripts/check-indexes.sh
+++ b/scripts/check-indexes.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+
+# Assert the hand-maintained indexes stay in sync with what is actually on disk.
+#
+# Adding an RFC, a registry, or a conformance fixture requires editing several
+# separate index locations by hand. Nothing else in CI notices when one of them
+# is missed, so drift accumulates silently (see issue #71). This script closes
+# that gap for the exhaustive enumerations:
+#
+#   RFCs        -> README.md repo tree, rfcs/README.md, rfcs/RFC-MACP-0001.md,
+#                  CONTRIBUTING.md
+#   registries  -> README.md repo tree, registries/README.md
+#   fixtures    -> README.md repo tree
+#
+# Deliberately NOT checked: README.md's "Reading order" section. It is a curated
+# narrative path, not an enumeration — it collapses RFC-0007..0011 into a single
+# range entry and omits RFC-0004 on purpose. Treating it as an index would either
+# fail on main today or need per-file exemptions.
+#
+# Direction is one-way (every file on disk appears in every index). An index
+# entry pointing at a deleted file is not checked here.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${PROJECT_ROOT}"
+
+FAILURES=0
+CHECKS=0
+
+fail() {
+    echo "  [X] $1"
+    FAILURES=$((FAILURES + 1))
+}
+
+section_result() {
+    if [ "${FAILURES}" -eq "$1" ]; then
+        echo "  [OK] $2"
+    else
+        echo "  --   $2"
+    fi
+}
+
+# Extract one indented block out of a repo-tree code fence: everything after the
+# header line up to the next blank line.
+tree_block() {
+    awk -v hdr="$2" '$0 ~ hdr { inblk = 1; next } inblk && /^[[:space:]]*$/ { exit } inblk { print }' "$1"
+}
+
+require_block() {
+    if [ -z "$1" ]; then
+        echo "Error: could not locate the '$2' block in README.md's repo tree."
+        echo "       The tree layout changed — update tree_block() in $0."
+        exit 1
+    fi
+}
+
+README_RFCS="$(tree_block README.md '^  rfcs/$')"
+README_REGISTRIES="$(tree_block README.md '^  registries/$')"
+README_CONFORMANCE="$(tree_block README.md '^    conformance/$')"
+
+require_block "${README_RFCS}" "rfcs/"
+require_block "${README_REGISTRIES}" "registries/"
+require_block "${README_CONFORMANCE}" "conformance/"
+
+echo "Checking index sync..."
+echo ""
+
+# -- RFCs -------------------------------------------------------------------
+# The glob matches the numbered spec documents only; rfcs/RFC-MACP-0001.md (the
+# stable compatibility index) has no descriptive suffix and is skipped.
+echo "-- RFCs (rfcs/RFC-MACP-*-*.md) --"
+BEFORE=${FAILURES}
+for rfc_file in rfcs/RFC-MACP-*-*.md; do
+    base="$(basename "${rfc_file}")"
+    num="$(echo "${base}" | sed -E 's/^(RFC-MACP-[0-9]{4}).*/\1/')"
+    CHECKS=$((CHECKS + 1))
+
+    grep -qF "${base}" <<<"${README_RFCS}" \
+        || fail "${base} is missing from README.md's repo tree (rfcs/ block)"
+    grep -qF "**${num} " rfcs/README.md \
+        || fail "${num} is missing from rfcs/README.md's RFC set bullets"
+    grep -qF "(${base})" rfcs/RFC-MACP-0001.md \
+        || fail "${base} is missing from rfcs/RFC-MACP-0001.md's Normative RFCs bullets"
+    grep -qF "(rfcs/${base})" CONTRIBUTING.md \
+        || fail "${base} is missing from CONTRIBUTING.md's Normative RFCs list"
+done
+section_result "${BEFORE}" "${CHECKS} RFC file(s) checked against 4 indexes"
+echo ""
+
+# -- Registries -------------------------------------------------------------
+echo "-- Registries (registries/*.md) --"
+BEFORE=${FAILURES}
+REGISTRY_COUNT=0
+for registry_file in registries/*.md; do
+    base="$(basename "${registry_file}")"
+    [ "${base}" = "README.md" ] && continue
+    REGISTRY_COUNT=$((REGISTRY_COUNT + 1))
+    CHECKS=$((CHECKS + 1))
+
+    grep -qF "(${base})" registries/README.md \
+        || fail "${base} is missing from registries/README.md's registry list"
+    grep -qF "${base}" <<<"${README_REGISTRIES}" \
+        || fail "${base} is missing from README.md's repo tree (registries/ block)"
+done
+section_result "${BEFORE}" "${REGISTRY_COUNT} registry file(s) checked against 2 indexes"
+echo ""
+
+# -- Conformance fixtures ---------------------------------------------------
+# schema.json is the fixture-format schema, not a fixture. Vector packs live in
+# their own subdirectory with their own schema and are listed by directory.
+echo "-- Conformance fixtures (schemas/conformance/*.json) --"
+BEFORE=${FAILURES}
+FIXTURE_COUNT=0
+for fixture_file in schemas/conformance/*.json; do
+    base="$(basename "${fixture_file}")"
+    [ "${base}" = "schema.json" ] && continue
+    FIXTURE_COUNT=$((FIXTURE_COUNT + 1))
+    CHECKS=$((CHECKS + 1))
+
+    grep -qF "${base}" <<<"${README_CONFORMANCE}" \
+        || fail "${base} is missing from README.md's fixture list (conformance/ block)"
+done
+section_result "${BEFORE}" "${FIXTURE_COUNT} fixture file(s) checked against 1 index"
+echo ""
+
+echo "-------------------------------------"
+if [ ${FAILURES} -gt 0 ]; then
+    echo "[X] ${FAILURES} missing index entr$([ ${FAILURES} -eq 1 ] && echo y || echo ies) across ${CHECKS} checked file(s)"
+    echo "    Add the file(s) named above to the index location(s) named above."
+    exit 1
+fi
+
+echo "[OK] All indexes in sync (${CHECKS} files checked)"


### PR DESCRIPTION
Closes #71.

## What

Adds `scripts/check-indexes.sh` and wires it into `make validate` and the CI `validate` job (right after the commitment-hash vector check). It asserts that every file on disk appears in every index that enumerates it:

| On disk | Must appear in |
|---|---|
| `rfcs/RFC-MACP-*-*.md` | `README.md` repo tree · `rfcs/README.md` RFC set bullets · `rfcs/RFC-MACP-0001.md` Normative RFCs · `CONTRIBUTING.md` Normative RFCs |
| `registries/*.md` | `registries/README.md` registry list · `README.md` repo tree |
| `schemas/conformance/*.json` | `README.md` fixture list |

37 files, 4+2+1 index locations. No third-party dependencies — plain bash, `awk`, `grep`.

## Acceptance criteria

- **First run on `main` is green.** No content fixes were needed; #67's Phase 6 had already repaired all known drift.
- **Wired into `make validate` and CI**, alongside the existing `conformance-lint` / `cmt-hash-vectors` steps.
- **Drift fails with a specific message.** Verified by adding throwaway `rfcs/RFC-MACP-0014-imaginary.md`, `registries/imaginary.md`, and `schemas/conformance/imaginary_happy_path.json`:

```
-- RFCs (rfcs/RFC-MACP-*-*.md) --
  [X] RFC-MACP-0014-imaginary.md is missing from README.md's repo tree (rfcs/ block)
  [X] RFC-MACP-0014 is missing from rfcs/README.md's RFC set bullets
  [X] RFC-MACP-0014-imaginary.md is missing from rfcs/RFC-MACP-0001.md's Normative RFCs bullets
  [X] RFC-MACP-0014-imaginary.md is missing from CONTRIBUTING.md's Normative RFCs list
...
[X] 7 missing index entries across 40 checked file(s)
```

## Scope note — `README.md`'s "Reading order" is excluded

The issue listed reading order as a third RFC index. It is not an enumeration: it collapses RFC-0007..0011 into one range entry and omits RFC-0004 (Security) on purpose. Checking it would either fail on `main` today or need a hardcoded exemption list, so the script checks the README **repo tree** instead — which does list every RFC file — and documents the omission in its header. RFCs are still covered by four independent indexes.

Direction is one-way (disk → index). An index entry pointing at a deleted file is not checked.

Also documents the check in `CONTRIBUTING.md` (RFC Proposals step 3, Registry Additions, Technical Requirements) so a CI failure is actionable.

## Verification

`make validate` passes end to end locally (JSON schema, examples, conformance lint, hash vectors, index sync, buf lint, protoc, proto sync).