### PR TITLE
rfcs: specify the subscribe sequence, vote cardinality, and intent

### DIFF
--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -184,6 +184,7 @@ A session is created by accepting a valid `SessionStart` message.
 
 A valid `SessionStart` message consists of an Envelope with a non-empty `session_id`, a non-empty `mode` field (the Mode identifier), and a non-empty `sender`, combined with a `SessionStartPayload` that MUST bind:
 
+- `intent` (MAY be empty; descriptive only — see below),
 - `mode_version`,
 - `configuration_version`,
 - `ttl_ms` (MUST be greater than zero),
@@ -195,6 +196,10 @@ A valid `SessionStart` message consists of an Envelope with a non-empty `session
 - `extensions` when present (see §7.4.2).
 
 `configuration_version` is an opaque string that identifies a mode-specific configuration profile. Its format and interpretation are implementation-defined and not part of the MACP interoperability contract. Runtimes MUST store the bound `configuration_version` in session metadata for replay integrity.
+
+`intent` is a human-readable description of why the session was opened. It MAY be empty, and a runtime MUST NOT reject a `SessionStart` solely because `intent` is empty. When present, a runtime MUST preserve it verbatim and MUST NOT modify it after the `SessionStart` is accepted — like the other bound values, it is immutable for the life of the session.
+
+`intent` is descriptive only. It MUST NOT influence acceptance decisions, Mode semantics, or policy evaluation, and it is therefore outside the determinism boundary of RFC-MACP-0003 Section 3: two sessions differing only in `intent` MUST produce identical state transitions. Note that `intent` is not carried on `SessionMetadata`, so it is not returned by `GetSession`; consumers that need it read it from the accepted `SessionStart` envelope in session history.
 
 A Mode MAY also bind additional immutable authority roles through the accepted `SessionStart` sender or through mode-specific policy encoded in bound session context.
 

--- a/rfcs/RFC-MACP-0006-transport-bindings.md
+++ b/rfcs/RFC-MACP-0006-transport-bindings.md
@@ -2,10 +2,12 @@
 # Multi-Agent Coordination Protocol (MACP) — Transport Bindings
 
 **Document:** RFC-MACP-0006
-**Version:** 1.2.0-draft
+**Version:** 1.3.0-draft
 **Status:** Community Standards Track
 **Updates:** RFC-MACP-0001
 
+> **Changelog — 1.3.0-draft:** §3.2 now defines what the passive-subscribe sequence *is* — the 1-based ordinal of accepted session-scoped envelopes, exclusive `after_sequence`, internal entries consuming no ordinals, stability across restart and compaction, and `FAILED_PRECONDITION` for a resume below the compacted base. Previously the sequence was specified only behaviorally ("starting from `after_sequence + 1`"), which left clients no defined way to compute their own position.
+>
 > **Changelog — 1.2.0-draft:** §3.8 now describes the paged `ListSessions` contract (`page_size`, opaque `page_token`, `next_page_token`), which shipped in `core.proto` without a matching prose update. The prose is a correction, not a wire change: it states what the proto already defines, including that only an empty `next_page_token` signals completion.
 >
 > **Changelog — 1.1.0-draft:** passive session subscription is promoted from the former Appendix A.1 to core `StreamSession` semantics in §3.2. `subscribe_session_id` and `after_sequence` are normative on every runtime that advertises `sessions.stream = true`; they are not an optional capability.
@@ -106,6 +108,19 @@ On a request with `subscribe_session_id` set, a runtime that advertises `session
 2. Replay accepted session envelopes in strict acceptance order starting from `after_sequence + 1`. When `after_sequence = 0`, replay begins at the session's first accepted envelope.
 3. Switch seamlessly to live broadcast on the same stream after replay drains, preserving within-session acceptance order.
 4. Never replay rejected envelopes (RFC-MACP-0001 §7.2); only accepted-history envelopes are delivered.
+
+**Sequence semantics.** For resume to be interoperable, a runtime MUST implement `after_sequence` against the following definition of the session sequence:
+
+- The sequence is the **1-based ordinal of accepted session-scoped envelopes**, assigned in acceptance order. The first envelope accepted on a session has ordinal 1.
+- Entries a runtime records for its own bookkeeping — the `SessionSuspend` / `SessionResume` annotations of RFC-MACP-0001 §7.5, TTL expiry, storage checkpoints, and any other internal log entry — MUST NOT consume ordinals. Client-visible ordinals are therefore contiguous.
+- `after_sequence` is **exclusive**. Replay resumes at `after_sequence + 1`; `after_sequence = 0` replays from the session's first accepted envelope.
+
+The Envelope carries no sequence field on the wire (RFC-MACP-0001 §6), so a client can determine its position only by counting the envelopes delivered to it. Two obligations follow, and a runtime MUST satisfy both:
+
+1. The envelopes delivered on a subscribe stream MUST be exactly those that consume ordinals. A runtime MUST NOT deliver an internal annotation on this stream: a client cannot distinguish it from an ordinal-consuming envelope, and would over-count.
+2. An ordinal MUST be stable for the life of the session — across runtime restarts, storage migration, and log compaction. A runtime that renumbers accepted envelopes breaks every resuming client silently, because the client asks to continue from a position that no longer denotes the same envelope and history is skipped or repeated with no error surface.
+
+**Compaction.** A runtime that compacts session history MUST record, in the compaction checkpoint, the number of accepted ordinals it discarded, so that surviving envelopes retain their original ordinals instead of being renumbered from 1. A resume whose `after_sequence` falls below the compacted base MUST be rejected with gRPC status `FAILED_PRECONDITION`, identifying the lowest ordinal still available; it MUST NOT be silently served from the oldest surviving envelope. As with §3.8's `INVALID_ARGUMENT`, this is a transport status rather than a MACP error code — the codes in [`registries/error-codes.md`](../registries/error-codes.md) are envelope-scoped, and a resume request carries no Envelope.
 
 A stream opened with a passive-subscribe frame is conventionally read-only. Implementations MAY refuse subsequent envelope frames on such a stream; clients that intend to coordinate on the session SHOULD open a separate `StreamSession` or use unary `Send`.
 

--- a/rfcs/RFC-MACP-0007-decision-mode.md
+++ b/rfcs/RFC-MACP-0007-decision-mode.md
@@ -76,7 +76,7 @@ Implementations of `macp.mode.decision.v1` MUST enforce the following:
 
 1. `Proposal.proposal_id` MUST be unique within the Session.
 2. `Evaluation`, `Objection`, and `Vote` MUST reference an existing `proposal_id`.
-3. A participant MAY cast at most one `Vote` per `proposal_id` unless a stricter or more permissive rule is explicitly bound in configuration. Base Decision Mode v1 assumes one vote per participant per proposal.
+3. A participant MUST cast at most one `Vote` per `proposal_id`. A runtime MUST reject a second `Vote` from the same sender for the same `proposal_id`; the first accepted `Vote` stands. Configuration MAY bind a *stricter* rule (for example, restricting which participants may vote at all), but MUST NOT relax this one. A permissive multi-vote rule would need replacement or tally semantics that this mode does not define, and without them two conforming implementations could tally identical accepted history differently — which Section 7's semantic-deterministic claim forbids.
 4. The runtime or policy authority MUST reject `Commitment` from unauthorized senders.
 5. The Session MUST NOT resolve before at least one proposal exists unless policy explicitly allows a no-go outcome with zero proposals.
 


### PR DESCRIPTION
Closes #43, #42, #41.

Three gaps with the same shape: the only definition of a behavior lived in one implementation instead of the spec. Each is written down as what that implementation already does — **no code change is required anywhere by this PR** — before a second implementation makes a different choice and the divergence has to be reconciled rather than specified.

---

## #43 — RFC-0006 §3.2, what the subscribe sequence *is*

The RFC defined `after_sequence` only behaviorally ("starting from `after_sequence + 1`") and never said what the ordinal counts. §3.2 now defines it:

- 1-based ordinal of accepted session-scoped envelopes, assigned in acceptance order
- `after_sequence` exclusive; `0` replays from the first accepted envelope
- internal entries (`SessionSuspend`/`SessionResume`, TTL expiry, checkpoints) consume **no** ordinals, so client-visible ordinals are contiguous

The Envelope carries no sequence field on the wire, so a client can only find its position by **counting what it is delivered**. That makes two obligations load-bearing, and both are now explicit:

1. the delivered set MUST equal the ordinal-consuming set — a runtime MUST NOT put an internal annotation on the stream, since a client cannot tell it apart from a real envelope and would over-count;
2. ordinals MUST be stable across restart, storage migration, and compaction.

**Compaction** MUST record the discarded ordinal count so survivors keep their original numbers, and a resume below the compacted base MUST fail `FAILED_PRECONDITION` naming the lowest available ordinal — never be silently served from the oldest surviving envelope.

*Why this one mattered most:* the failure mode is a resuming client silently skipping or re-receiving history with no error surface, and both SDKs already consume `after_sequence` (`client.py`, `client.ts`, `transports.ts`). macp-runtime originally got this wrong by exposing a raw log index.

Verified against the implementation, not just the issue text: suspend/resume are written via `make_internal_entry` and are **never** passed to `publish_accepted_envelope`, so obligation (1) already holds in the only runtime — which is exactly what makes client-side counting sound today.

Version `1.2.0-draft` → `1.3.0-draft` + changelog.

## #42 — RFC-0007 §5.3, vote cardinality

The "or more permissive" escape hatch permitted multiple votes per participant with no defined tally or replacement semantics — directly contradicting §7's **semantic-deterministic** claim, since two conforming implementations could tally identical accepted history differently.

Three implementations already disagree in code:

| Implementation | Behavior |
|---|---|
| `macp-runtime` `decision.rs:217` | rejects the duplicate → **first wins** |
| Python SDK `projections.py:103` | overwrites by sender → **last wins** |
| TS SDK `projections/decision.ts:72` | overwrites by sender → **last wins** |

Latent today — the runtime never admits a second vote into accepted history, so the SDKs' branch is unreachable *against this runtime*. It stops being latent the moment any deployment binds the permissive rule §5.3 currently blesses.

**Dropped the permissive branch** rather than defining last-wins. It matches what the only runtime enforces, requires no code change anywhere, and converts the SDK branch from "undefined" to "unreachable". Defining last-wins instead would have required a runtime change and made duplicate voting a supported feature. Stricter configuration is still permitted. This also aligns §5.3 with RFC-0011 §5, which already says "at most one ballot" with no escape hatch.

## #41 — RFC-0001 §7.1, `SessionStartPayload.intent`

Field 1 appears in every example transcript and is required by `macp-agent-bootstrap.schema.json`, yet was absent from §7.1's binding requirements — leaving open whether it may be empty, whether it is immutable, and whether it affects replay. Documented as what the runtime does:

- MAY be empty, and a runtime MUST NOT reject a `SessionStart` solely because it is empty
- preserved verbatim, immutable once accepted
- descriptive only: MUST NOT influence acceptance, Mode semantics, or policy, and is outside RFC-0003 §3's determinism boundary

Also records a fact that surprised me while checking: `intent` is **not** on `SessionMetadata`, so `GetSession` never returns it. Consumers read it from the accepted `SessionStart` in session history. (Adding it to the proto would be a wire change — deliberately not done here.)

---

## Verification

- Swept `docs/`, `registries/`, and all 18 conformance fixtures for text that would now contradict any of the three: none found.
- Programmatically checked every fixture for a duplicate accepted `Vote` from the same sender on the same `proposal_id` — none, so #42's tightening invalidates no existing fixture.
- `make validate` green.

https://claude.ai/code/session_01SnWv7RXw2fiTmCNUmVoRmu