### PR TITLE
test(conformance): fixture duplicate ballots and the three unfixtured payloads

### DIFF
--- a/schemas/conformance/README.md
+++ b/schemas/conformance/README.md
@@ -80,6 +80,16 @@ Notes:
   `ABSTAIN`); fixtures must use the uppercase form.
 - Proto `bytes` payload fields (e.g. `context`) are written as plain strings and
   UTF-8 encoded by the harnesses.
+- Every ballot/vote-bearing mode fixtures an *accepted* first ballot followed
+  by a *rejected* duplicate from the same sender for the same
+  `proposal_id`/`request_id` (`decision_reject_paths.json`,
+  `quorum_reject_paths.json` — the latter includes a cross-type case, since
+  the per-`request_id` cap in RFC-MACP-0011 §5 rule 3 is counted across
+  `Approve`/`Reject`/`Abstain` combined). `ObjectionPayload`
+  (`decision_happy_path.json`, `decision_reject_paths.json`),
+  `WithdrawPayload` (`proposal_reject_paths.json`), and `TaskUpdatePayload`
+  (`task_reject_paths.json`) each have at least one accepted and one
+  RFC-cited rejected instance.
 
 ## Source of truth & enforcement
 

--- a/schemas/conformance/decision_happy_path.json
+++ b/schemas/conformance/decision_happy_path.json
@@ -24,6 +24,18 @@
       "expect": "accept"
     },
     {
+      "_comment": "RFC-MACP-0007 Section 4 (:62-64): Objection is a formal blocking action distinct from a BLOCK Evaluation, with an explicit severity level.",
+      "sender": "agent://b",
+      "message_type": "Objection",
+      "payload_type": "macp.modes.decision.v1.ObjectionPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "reason": "deployment window overlaps a scheduled freeze",
+        "severity": "critical"
+      },
+      "expect": "accept"
+    },
+    {
       "sender": "agent://a",
       "message_type": "Vote",
       "payload_type": "macp.modes.decision.v1.VotePayload",
@@ -67,6 +79,13 @@
         "sender": "agent://orchestrator"
       }
     },
+    "objections": [
+      {
+        "proposal_id": "p1",
+        "severity": "critical",
+        "sender": "agent://b"
+      }
+    ],
     "votes": {
       "p1": {
         "agent://a": {

--- a/schemas/conformance/decision_reject_paths.json
+++ b/schemas/conformance/decision_reject_paths.json
@@ -37,6 +37,19 @@
       "expect": "accept"
     },
     {
+      "_comment": "RFC-MACP-0007 Section 5 rule 2 (:78): Objection MUST reference an existing proposal_id.",
+      "sender": "agent://b",
+      "message_type": "Objection",
+      "payload_type": "macp.modes.decision.v1.ObjectionPayload",
+      "payload": {
+        "proposal_id": "p-does-not-exist",
+        "reason": "cannot evaluate an objection against a proposal that was never submitted",
+        "severity": "high"
+      },
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
+    },
+    {
       "sender": "agent://a",
       "message_type": "Commitment",
       "payload_type": "macp.v1.CommitmentPayload",
@@ -63,6 +76,19 @@
         "reason": "good"
       },
       "expect": "accept"
+    },
+    {
+      "_comment": "RFC-MACP-0007 Section 5 rule 3: a second, distinct Vote from a sender who already cast one for the same proposal_id MUST be rejected; the first accepted Vote stands.",
+      "sender": "agent://a",
+      "message_type": "Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
+      "payload": {
+        "proposal_id": "p1",
+        "vote": "REJECT",
+        "reason": "changed my mind after re-reading the proposal"
+      },
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     },
     {
       "sender": "agent://b",

--- a/schemas/conformance/proposal_reject_paths.json
+++ b/schemas/conformance/proposal_reject_paths.json
@@ -39,11 +39,65 @@
       },
       "expect": "reject",
       "expected_error_code": "INVALID_ENVELOPE"
+    },
+    {
+      "sender": "agent://seller",
+      "message_type": "Proposal",
+      "payload_type": "macp.modes.proposal.v1.ProposalPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "title": "offer",
+        "summary": "terms",
+        "details": [],
+        "tags": []
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://buyer",
+      "message_type": "CounterProposal",
+      "payload_type": "macp.modes.proposal.v1.CounterProposalPayload",
+      "payload": {
+        "proposal_id": "p2",
+        "supersedes_proposal_id": "p1",
+        "title": "counter",
+        "summary": "revised terms"
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "RFC-MACP-0008 Section 2.1 (:32) and Section 5 rule 3 (:68): a CounterProposal mints a new proposal_id, and only the sender of that CounterProposal may withdraw it -- the original proposer of a superseded proposal has no withdrawal authority over the counter-proposal.",
+      "sender": "agent://seller",
+      "message_type": "Withdraw",
+      "payload_type": "macp.modes.proposal.v1.WithdrawPayload",
+      "payload": {
+        "proposal_id": "p2",
+        "reason": "seller did not author this counter-proposal"
+      },
+      "expect": "reject",
+      "expected_error_code": "FORBIDDEN"
+    },
+    {
+      "sender": "agent://buyer",
+      "message_type": "Withdraw",
+      "payload_type": "macp.modes.proposal.v1.WithdrawPayload",
+      "payload": {
+        "proposal_id": "p2",
+        "reason": "withdrawing my own counter-proposal"
+      },
+      "expect": "accept"
     }
   ],
   "expected_final_state": "Open",
   "expect_resolution_present": false,
   "expected_mode_state": {
-    "phase": "Negotiating"
+    "phase": "Negotiating",
+    "proposals": {
+      "p2": {
+        "proposal_id": "p2",
+        "proposer": "agent://buyer",
+        "disposition": "Withdrawn"
+      }
+    }
   }
 }

--- a/schemas/conformance/proposal_reject_paths.json
+++ b/schemas/conformance/proposal_reject_paths.json
@@ -66,7 +66,7 @@
       "expect": "accept"
     },
     {
-      "_comment": "RFC-MACP-0008 Section 2.1 (:32) and Section 5 rule 3 (:68): a CounterProposal mints a new proposal_id, and only the sender of that CounterProposal may withdraw it -- the original proposer of a superseded proposal has no withdrawal authority over the counter-proposal.",
+      "_comment": "RFC-MACP-0008 Section 2.1 (:32): a CounterProposal mints a new proposal_id, and only the sender of that CounterProposal may withdraw it -- the original proposer of a superseded proposal has no withdrawal authority over the counter-proposal.",
       "sender": "agent://seller",
       "message_type": "Withdraw",
       "payload_type": "macp.modes.proposal.v1.WithdrawPayload",

--- a/schemas/conformance/quorum_reject_paths.json
+++ b/schemas/conformance/quorum_reject_paths.json
@@ -60,6 +60,40 @@
       },
       "expect": "reject",
       "expected_error_code": "INVALID_ENVELOPE"
+    },
+    {
+      "_comment": "RFC-MACP-0011 Section 5 rule 3: a second, distinct ballot from a sender who already cast one for the same request_id MUST be rejected, even when it repeats the same ballot type; the first accepted ballot stands.",
+      "sender": "agent://alice",
+      "message_type": "Approve",
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
+      "payload": {
+        "request_id": "r1",
+        "reason": "still lgtm, resending"
+      },
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
+    },
+    {
+      "sender": "agent://bob",
+      "message_type": "Approve",
+      "payload_type": "macp.modes.quorum.v1.ApprovePayload",
+      "payload": {
+        "request_id": "r1",
+        "reason": "agree"
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "RFC-MACP-0011 Section 5 rule 3: the per-request_id cap is counted across Approve, Reject, and Abstain combined -- a cross-type second ballot (Reject after an accepted Approve) from the same sender MUST be rejected regardless of the type of either ballot.",
+      "sender": "agent://bob",
+      "message_type": "Reject",
+      "payload_type": "macp.modes.quorum.v1.RejectPayload",
+      "payload": {
+        "request_id": "r1",
+        "reason": "actually changed my mind"
+      },
+      "expect": "reject",
+      "expected_error_code": "INVALID_ENVELOPE"
     }
   ],
   "expected_final_state": "Open"

--- a/schemas/conformance/task_reject_paths.json
+++ b/schemas/conformance/task_reject_paths.json
@@ -50,6 +50,43 @@
       },
       "expect": "reject",
       "expected_error_code": "INVALID_ENVELOPE"
+    },
+    {
+      "sender": "agent://worker",
+      "message_type": "TaskAccept",
+      "payload_type": "macp.modes.task.v1.TaskAcceptPayload",
+      "payload": {
+        "task_id": "t1",
+        "assignee": "agent://worker",
+        "reason": "ready"
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "RFC-MACP-0009 Section 4 (:31, :58) and Section 5 rule 4 (:73): TaskUpdate does not carry an explicit assignee field -- authorship is validated via the Envelope sender, which MUST match the active assignee. A non-assignee sender (here, the requester) MUST be rejected.",
+      "sender": "agent://planner",
+      "message_type": "TaskUpdate",
+      "payload_type": "macp.modes.task.v1.TaskUpdatePayload",
+      "payload": {
+        "task_id": "t1",
+        "status": "in_progress",
+        "progress": 0.5,
+        "message": "requester is not the active assignee"
+      },
+      "expect": "reject",
+      "expected_error_code": "FORBIDDEN"
+    },
+    {
+      "sender": "agent://worker",
+      "message_type": "TaskUpdate",
+      "payload_type": "macp.modes.task.v1.TaskUpdatePayload",
+      "payload": {
+        "task_id": "t1",
+        "status": "in_progress",
+        "progress": 0.5,
+        "message": "halfway through"
+      },
+      "expect": "accept"
     }
   ],
   "expected_final_state": "Open"


### PR DESCRIPTION
## :warning: DO NOT MERGE until three downstream vendoring PRs are staged

This is the fan-out PR from `plans/conformance-cardinality-program.md` Wave 2 / `multiagentcoordinationprotocol-ballot-cardinality-and-fixtures.md` phase S3. `macp-runtime`, `macp-sdk-typescript`, and `macp-sdk-python` all vendor `schemas/conformance/` byte-identically and enforce it in CI (byte-diff drift guards plus replay). **Merging this PR turns all three downstream repos' CI red simultaneously** — that is expected, not a bug, but it means landing must be coordinated:

1. Open (but do not merge) this PR.
2. In each of the three downstream repos, open a vendoring PR that runs `make sync-fixtures` (or the runtime's equivalent) against this branch and gets green.
3. Only once all three vendoring PRs are green against this branch should this PR (and then the three vendoring PRs) be merged, in that order.

### What each downstream repo needs to do

- **macp-runtime**: `make sync-fixtures` equivalent / copy the five changed fixtures into `tests/conformance/`. **Also needs a source change**: `tests/conformance_loader.rs`'s `encode_task_payload()` has no `"TaskUpdate"` branch today, so it cannot replay the new `TaskUpdatePayload` fixture until one is added (see the encoder branches for `TaskComplete`/`TaskFail` for the pattern — `TaskUpdatePayload` has `task_id`, `status`, `progress`, `message`, `partial_output`). `ObjectionPayload` and `WithdrawPayload` already have decode support in the loader, so those two need no code change, only the fixture sync.
- **macp-sdk-typescript**: `make sync-fixtures`; confirm `tests/conformance/duplicate-ballots.ts` (scoped to `expect === 'accept'`, per its own comment) does not flag the new *rejected* duplicates, and that its transcript/projection replay decodes `Objection`, `Withdraw`, and `TaskUpdate` payloads (first-ever exercise of these three decode paths).
- **macp-sdk-python**: `make sync-fixtures`; same decode-path check for `Objection`/`Withdraw`/`TaskUpdate`.

## Summary

Closes #84 and #81.

**Group A — duplicate reject paths (#84).** Neither `decision_reject_paths.json` nor `quorum_reject_paths.json` had an accepted first vote/ballot followed by a rejected duplicate from the same sender.

- `decision_reject_paths.json` — accepted `Vote` (agent://a, APPROVE) followed by a distinct second `Vote` (agent://a, REJECT) for the same `proposal_id`, rejected `INVALID_ENVELOPE`. Pins RFC-MACP-0007 §5 rule 3.
- `quorum_reject_paths.json` — accepted `Approve` (agent://alice) followed by a duplicate `Approve` from the same sender (rejected), **plus a cross-type case**: agent://bob's accepted `Approve` followed by a `Reject` from the same sender (rejected). Pins RFC-MACP-0011 §5 rule 3 as rewritten in `cd5ac2b` ("counted across `Approve`, `Reject`, and `Abstain` combined ... regardless of the type of either ballot").

**Group B — the three unfixtured payloads (#81).** First-ever fixtures for three normatively-specified types with zero prior coverage:

- **`Objection`** (decision) — `decision_happy_path.json` gets a valid `critical`-severity Objection between `Proposal` and `Vote` (while phase is still `Evaluation`); `decision_reject_paths.json` gets the RFC-MACP-0007 `:78` reject path (Objection referencing a `proposal_id` that was never submitted). This is the highest-value fixture in the plan — `has_blocking_objection`-style veto governance in both SDKs has had no cross-implementation oracle until now.
- **`Withdraw`** (proposal) — `proposal_reject_paths.json` gets a `CounterProposal` (mints `proposal_id` `p2`), a rejected `Withdraw` of `p2` from the *original* proposer (not the `CounterProposal`'s author) pinning the RFC-MACP-0008 `:32`/`:68` authorship rule, and an accepted `Withdraw` of `p2` from its actual author.
- **`TaskUpdate`** (task) — `task_reject_paths.json` gets a `TaskAccept` establishing the active assignee, a rejected `TaskUpdate` from the non-assignee requester (pins the RFC-MACP-0009 `:73` rule that authorship is validated via the Envelope `sender` against the active assignee, not a payload field), and an accepted `TaskUpdate` from the actual assignee.

`schemas/conformance/README.md` gets a short note listing where each of these now lives, since the corpus had no positive statement of this coverage before.

## Verification

All run from the spec repo root on this branch:

```
$ python3 schemas/conformance/lint_fixtures.py
ok   decision_happy_path.json
... (all 17 files) ...
All 17 conformance fixtures are internally consistent.

$ bash scripts/check-indexes.sh
[OK] All indexes in sync (37 files checked)

$ bash scripts/validate-json.sh
[OK] All 42/42 JSON files validated
```

**Reference-implementation replay** (per the plan's constraint 1): the five changed fixtures were copied into a **scratch git worktree copy** of `macp-runtime` (not the working tree — `cp -r` into the session scratchpad), with a temporary local addition of the missing `TaskUpdate` branch to `tests/conformance_loader.rs`'s `encode_task_payload()` (needed only to exercise the harness; not committed anywhere). `cargo test --test conformance_loader` there:

```
running 18 tests
test conformance_decision_reject_paths ... ok
test conformance_quorum_reject_paths ... ok
test conformance_decision_negative_outcome ... ok
test conformance_decision_happy_path ... ok
test conformance_handoff_reject_paths ... ok
test conformance_multi_round_reject_paths ... ok
test conformance_handoff_happy_path ... ok
test conformance_proposal_negative_outcome ... ok
test conformance_handoff_negative_outcome ... ok
test conformance_proposal_happy_path ... ok
test conformance_quorum_happy_path ... ok
test conformance_proposal_reject_paths ... ok
test conformance_quorum_negative_outcome ... ok
test conformance_task_reject_paths ... ok
test conformance_task_negative_outcome ... ok
test conformance_task_happy_path ... ok
test conformance_multi_round_happy_path ... ok
test fixtures_conform_to_canonical_format ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Every new reject path asserts and matches its declared `expected_error_code` against the real runtime; every new accept path replays cleanly. No existing fixture's expectations were touched.

## Finding worth flagging

`macp-runtime`'s own conformance harness (`tests/conformance_loader.rs`) cannot replay a `TaskUpdate` fixture today — `encode_task_payload()` has branches for `TaskRequest`/`TaskAccept`/`TaskComplete`/`TaskFail` but not `TaskUpdate`, even though the production mode implementation (`crates/macp-modes/src/mode/task.rs`) has handled `TaskUpdate` all along. This is exactly the "harness capability is a prerequisite" risk the plan calls out — closing it is in scope for macp-runtime's vendoring PR, not this one.