### PR TITLE
rfcs: fix Progress ambient-mode gap and lint's SessionCancel carve-out

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,10 +187,10 @@ package macp.v1;
 
 message Envelope {
   string macp_version = 1;
-  string mode = 2;                // empty for Ambient Signals
+  string mode = 2;                // empty for Ambient Signals; empty or non-empty for Progress (§6)
   string message_type = 3;
   string message_id = 4;
-  string session_id = 5;          // empty for Signals
+  string session_id = 5;          // empty for Signals; empty or non-empty for Progress (§6)
   string sender = 6;
   int64  timestamp_unix_ms = 7;   // informational
   bytes  payload = 8;             // mode-defined

--- a/examples/json/progress_ambient.json
+++ b/examples/json/progress_ambient.json
@@ -1,0 +1,16 @@
+{
+  "macp_version": "1.0",
+  "mode": "",
+  "message_type": "Progress",
+  "message_id": "01HV0Q3A9K2M5R7T1WYB0F4C6D",
+  "session_id": "",
+  "sender": "agent://worker.render",
+  "timestamp": "2026-03-01T20:30:00Z",
+  "payload": {
+    "progress_token": "tok-render-0001",
+    "progress": 40,
+    "total": 100,
+    "message": "Rendering frame 40 of 100",
+    "target_message_id": "01HV0Q2F1B3N6S8U2XZC1G5D7E"
+  }
+}

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -167,7 +167,7 @@ For all accepted Envelopes:
 - `message_id` MUST be non-empty,
 - `sender` MUST be non-empty,
 - `session_id` and `mode` MUST both be empty for Ambient Signals,
-- `session_id` and `mode` MUST agree on `Progress`: a runtime MAY accept `Progress` either in ambient form (`session_id` and `mode` both empty, correlating to a session, if at all, only through a payload-defined field) or in session-scoped form (`session_id` and `mode` both non-empty); an Envelope with exactly one of the two empty MUST be rejected. This is a distinct rule from Signals: unlike Signals, `Progress` is not required to be ambient,
+- `session_id` and `mode` MUST agree on `Progress`: a runtime MAY accept `Progress` either in ambient form (`session_id` and `mode` both empty) or in session-scoped form (`session_id` and `mode` both non-empty); an Envelope with exactly one of the two empty MUST be rejected. Ambient `Progress` has no payload field that correlates it to a session; `ProgressPayload.target_message_id` correlates it only to the originating message. This is a distinct rule from Signals: unlike Signals, `Progress` is not required to be ambient,
 - for every other message type, `session_id` and `mode` MUST both be non-empty (session-scoped),
 - `sender` MUST be treated as authenticated/derived identity for session-scoped acceptance per RFC-MACP-0004, not as an untrusted self-asserted hint.
 

--- a/rfcs/RFC-MACP-0001-core.md
+++ b/rfcs/RFC-MACP-0001-core.md
@@ -166,8 +166,9 @@ For all accepted Envelopes:
 - `message_type` MUST be non-empty,
 - `message_id` MUST be non-empty,
 - `sender` MUST be non-empty,
-- `session_id` MUST be empty for Ambient Signals and non-empty for session-scoped messages,
-- `mode` MUST be empty for Ambient Signals and non-empty for session-scoped messages,
+- `session_id` and `mode` MUST both be empty for Ambient Signals,
+- `session_id` and `mode` MUST agree on `Progress`: a runtime MAY accept `Progress` either in ambient form (`session_id` and `mode` both empty, correlating to a session, if at all, only through a payload-defined field) or in session-scoped form (`session_id` and `mode` both non-empty); an Envelope with exactly one of the two empty MUST be rejected. This is a distinct rule from Signals: unlike Signals, `Progress` is not required to be ambient,
+- for every other message type, `session_id` and `mode` MUST both be non-empty (session-scoped),
 - `sender` MUST be treated as authenticated/derived identity for session-scoped acceptance per RFC-MACP-0004, not as an untrusted self-asserted hint.
 
 For Mode-defined payloads, `message_type` is interpreted relative to the Envelope's `mode`: `(mode, message_type)`, not `message_type` alone, is the discriminating key for a payload's declared type, and an implementation MUST NOT assume a given `message_type` denotes the same payload type across Modes. This is not a hypothetical concern — more than one Mode already declares the same payload name (for example, `ProposalPayload` is declared by both `macp.mode.decision.v1` and `macp.mode.proposal.v1`, and `RejectPayload` is declared by both `macp.mode.proposal.v1` and `macp.mode.quorum.v1`). Core types, by contrast, are mode-independent: `Signal`, `Progress`, `SessionStart`, `SessionCancel`, `SessionSuspend`, `SessionResume`, and `Commitment` each denote one payload type regardless of the Envelope's `mode`, corresponding one-to-one with the Core payload definitions listed above. This scopes the *interpretation* of `message_type` for Mode-defined payloads; it does not qualify the Core types. Per the rule above, `mode` MUST be empty for Ambient Signals, so such a Signal remains fully identified by `message_type` alone, with no `mode` to pair it with. Neither mode-independent types nor empty-`mode` Signals are made non-conforming by this rule. This clarifies how an existing discriminator is scoped; it does not establish a message-type registry.
@@ -396,8 +397,8 @@ MACP defines a canonical JSON mapping for interoperability with REST gateways, d
 |----------------|-----------|---------|
 | `timestamp_unix_ms` (int64) | `timestamp` | RFC3339 string (UTC recommended) |
 | `payload` (bytes) | `payload` or `payload_b64` | See §10.2 |
-| `mode` (string) | `mode` | Empty string for Ambient Signals; non-empty for session-scoped messages |
-| `session_id` (string) | `session_id` | Empty string for Ambient Signals |
+| `mode` (string) | `mode` | Empty string for Ambient Signals; empty or non-empty for `Progress` per §6; non-empty for all other message types |
+| `session_id` (string) | `session_id` | Empty string for Ambient Signals; empty or non-empty for `Progress` per §6; non-empty for all other message types |
 | All enum fields | Same name | String form of protobuf enum name |
 
 **Normative mapping rule:** In the canonical JSON form, the Protobuf field `timestamp_unix_ms` (int64, milliseconds since Unix epoch) is **renamed** to `timestamp` and **converted** to an RFC 3339 string. Encoders MUST perform this conversion when producing JSON. Decoders MUST convert `timestamp` back to `timestamp_unix_ms` when producing Protobuf. This is the only Protobuf-to-JSON field rename in the MACP envelope.

--- a/schemas/conformance/lint_fixtures.py
+++ b/schemas/conformance/lint_fixtures.py
@@ -95,10 +95,10 @@ def lint_fixture(path: Path) -> tuple[list[str], list[str]]:
             errors.append(f"messages[{i}].expect {expect!r} not in {sorted(VALID_EXPECT)}")
         # An ACCEPTED message must come from a participant — except the
         # initiator's role-based messages (SessionStart / Commitment /
-        # CancelSession), which do not require participant-list membership
+        # SessionCancel), which do not require participant-list membership
         # (see the initiator note above). A REJECTED message may legitimately
         # come from an outsider (that is often why it rejects).
-        initiator_role_messages = {"SessionStart", "Commitment", "CancelSession"}
+        initiator_role_messages = {"SessionStart", "Commitment", "SessionCancel"}
         # Mode-specific messages that are likewise issued by the initiator
         # ROLE: the quorum coordinator poses the question (RFC-0011 §2), the
         # task requester issues the request (RFC-0009 §4).

--- a/schemas/json/macp-envelope.schema.json
+++ b/schemas/json/macp-envelope.schema.json
@@ -21,7 +21,7 @@
     },
     "mode": {
       "type": "string",
-      "description": "Empty string for Ambient Signals; canonical mode identifier for session-scoped messages (for example macp.mode.decision.v1)."
+      "description": "Empty string for Ambient Signals; empty or non-empty for Progress (see §6, both forms are valid but MUST agree with session_id); canonical mode identifier for session-scoped messages (for example macp.mode.decision.v1)."
     },
     "message_type": {
       "type": "string",
@@ -35,7 +35,7 @@
     },
     "session_id": {
       "type": "string",
-      "description": "Empty string for Ambient Signals; non-empty for session-scoped messages."
+      "description": "Empty string for Ambient Signals; empty or non-empty for Progress (see §6, both forms are valid but MUST agree with mode); non-empty for session-scoped messages."
     },
     "sender": {
       "type": "string",

--- a/schemas/json/macp-envelope.schema.json
+++ b/schemas/json/macp-envelope.schema.json
@@ -114,8 +114,22 @@
             "$ref": "#/$defs/SignalPayload"
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "message_type": {
+            "not": {
+              "enum": ["Signal", "Progress"]
+            }
+          }
+        },
+        "required": [
+          "message_type"
+        ]
       },
-      "else": {
+      "then": {
         "properties": {
           "mode": {
             "minLength": 1
@@ -196,16 +210,32 @@
       },
       "then": {
         "properties": {
-          "mode": {
-            "minLength": 1
-          },
-          "session_id": {
-            "minLength": 1
-          },
           "payload": {
             "$ref": "#/$defs/ProgressPayload"
           }
-        }
+        },
+        "anyOf": [
+          {
+            "properties": {
+              "mode": {
+                "maxLength": 0
+              },
+              "session_id": {
+                "maxLength": 0
+              }
+            }
+          },
+          {
+            "properties": {
+              "mode": {
+                "minLength": 1
+              },
+              "session_id": {
+                "minLength": 1
+              }
+            }
+          }
+        ]
       }
     }
   ],

--- a/schemas/json/tests/invalid/README.md
+++ b/schemas/json/tests/invalid/README.md
@@ -15,6 +15,8 @@ itself never causes the rejection.
 |---------|---------------------|
 | `signal_with_session_id.json` | Signals are ambient: `mode` and `session_id` MUST be empty (RFC-MACP-0001 §6) |
 | `session_scoped_empty_session_id.json` | Session-scoped messages MUST carry non-empty `mode` and `session_id` (RFC-MACP-0001 §6) |
+| `progress_mode_without_session_id.json` | `Progress` MUST have `mode` and `session_id` both empty or both non-empty — mixed (non-empty `mode`, empty `session_id`) MUST be rejected (RFC-MACP-0001 §6) |
+| `progress_session_id_without_mode.json` | `Progress` MUST have `mode` and `session_id` both empty or both non-empty — mixed (empty `mode`, non-empty `session_id`) MUST be rejected (RFC-MACP-0001 §6) |
 | `payload_and_payload_b64.json` | `payload` and `payload_b64` are mutually exclusive (RFC-MACP-0001 §10) |
 | `missing_payload.json` | Exactly one of `payload` / `payload_b64` is required (RFC-MACP-0001 §10) |
 | `bad_macp_version.json` | `macp_version` MUST be semantic-version formatted |

--- a/schemas/json/tests/invalid/progress_mode_without_session_id.json
+++ b/schemas/json/tests/invalid/progress_mode_without_session_id.json
@@ -1,0 +1,15 @@
+{
+  "_invalid_because": "Progress MUST agree on mode/session_id: both empty (ambient) or both non-empty (session-scoped) (RFC-MACP-0001 §6). This Progress carries a non-empty mode but an empty session_id.",
+  "macp_version": "1.0.0",
+  "mode": "macp.mode.task.v1",
+  "message_type": "Progress",
+  "message_id": "msg-invalid-003",
+  "session_id": "",
+  "sender": "agent://worker",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "progress_token": "tok-001",
+    "progress": 40,
+    "total": 100
+  }
+}

--- a/schemas/json/tests/invalid/progress_session_id_without_mode.json
+++ b/schemas/json/tests/invalid/progress_session_id_without_mode.json
@@ -1,0 +1,15 @@
+{
+  "_invalid_because": "Progress MUST agree on mode/session_id: both empty (ambient) or both non-empty (session-scoped) (RFC-MACP-0001 §6). This Progress carries a non-empty session_id but an empty mode.",
+  "macp_version": "1.0.0",
+  "mode": "",
+  "message_type": "Progress",
+  "message_id": "msg-invalid-004",
+  "session_id": "sess-abc123",
+  "sender": "agent://worker",
+  "timestamp": "2026-07-07T00:00:00Z",
+  "payload": {
+    "progress_token": "tok-001",
+    "progress": 40,
+    "total": 100
+  }
+}


### PR DESCRIPTION
## Summary

- **#87** — RFC-MACP-0001 §6 stated the empty-`mode`/empty-`session_id` rule only for Ambient Signals, but the reference runtime (`macp-runtime`) also accepts ambient `Progress` (both empty) alongside session-scoped `Progress` (both non-empty). The JSON envelope schema (`schemas/json/macp-envelope.schema.json`) disagreed with *both* the RFC and the runtime: it forced `Progress` into session-scoped-only form (`mode`/`session_id` both `minLength: 1`), which would reject valid ambient `Progress` envelopes. Fixed by:
  - Restating §6's bullet list as three explicit rules: Signals (always both empty), `Progress` (both empty *or* both non-empty — an implementation MAY accept either form, but a mixed envelope MUST be rejected), and every other message type (always both non-empty).
  - Updating the §10.1 JSON-mapping table rows for `mode`/`session_id` to match and point at §6.
  - Restructuring the envelope schema's `allOf` so the "non-Signal" fallback excludes `Progress`, and giving `Progress` its own `anyOf` (both-empty branch / both-non-empty branch) instead of a hard `minLength: 1` requirement.
  - Correcting an overstated claim in the new §6 text: ambient `Progress` has no payload field that correlates it to a *session*. `ProgressPayload.target_message_id` (the only correlation field it carries) correlates it only to the originating *message*.
  - Aligning `properties.mode.description` / `properties.session_id.description` in the envelope schema, and the illustrative Envelope snippet in `docs/architecture.md`, with the tri-state rule (previously both still said only Signals get the empty form).
  - Adding negative fixtures for both mixed-`Progress` directions (`schemas/json/tests/invalid/progress_mode_without_session_id.json`, `progress_session_id_without_mode.json`) and a positive ambient-`Progress` example (`examples/json/progress_ambient.json`), so the new schema branch is actually exercised by `scripts/validate-json.sh` instead of only by manual `ajv` checks.
- **#88** — `schemas/conformance/lint_fixtures.py`'s initiator role carve-out listed `CancelSession`, which is the RPC name, not a `message_type` (the envelope `message_type` is `SessionCancel` per RFC-MACP-0001 and the runtime). The entry was dead code and `SessionCancel` was unintentionally left out of the carve-out. Fixed the set (and the comment above it) to say `SessionCancel`. Checked the rest of the carve-out list for the same RPC-vs-`message_type` confusion — no other entries were affected.

## Fixture corpus

No files under `schemas/conformance/*.json` were touched — only `lint_fixtures.py` itself.

**Correction:** an earlier version of this description implied the `#88` carve-out fix was validated by the fixture run. It was not. `grep -rn "SessionCancel\|CancelSession" schemas/conformance/*.json` returns **no matches** — no conformance fixture contains a `SessionCancel` message at all, so the carve-out (in either its old dead `CancelSession` spelling or the corrected `SessionCancel` spelling) is never reached by any fixture. `python3 schemas/conformance/lint_fixtures.py` passing 17/17 before and after is expected and uninteresting: it shows the rename introduced no regression, not that the corrected carve-out does anything. The fix is forward-looking (correct for the day a fixture exercises an initiator-issued `SessionCancel` from outside `participants`) rather than behavior-changing today.

```
Before fix: 17/17 fixtures pass ("CancelSession" — dead entry, unreachable by any fixture)
After fix:  17/17 fixtures pass ("SessionCancel" — correctly named, still unreached by any fixture)
```

## Companion macp-runtime fix required before merge

`macp-runtime`'s envelope validation (`src/server.rs`, `validate_envelope_shape`) only guards one direction of the `Progress` mixed-state rule: it checks that `session_id` empty implies `mode` empty, but never checks that `mode` empty implies `session_id` empty (or, equivalently, that non-empty `session_id` implies non-empty `mode`). Today the runtime **accepts** `Progress` with empty `mode` and a populated `session_id`, which this RFC (and the corrected JSON schema) would reject. Merging this RFC change first would make the reference runtime non-conforming to its own spec. A separate PR against `macp-runtime` is being opened to close that gap; this spec PR should not merge before (or without an explicit plan for) that runtime fix landing.

## Test plan

- [x] `python3 schemas/conformance/lint_fixtures.py` — 17/17 pass, unchanged before/after
- [x] `bash scripts/check-indexes.sh` — all indexes in sync
- [x] `bash scripts/validate-json.sh` — 45/45 JSON files validated (was 42/42; +3 for the new fixtures), including the new negative `Progress` fixtures (both mixed directions correctly rejected) and the new ambient-`Progress` positive example
- [x] Manual `ajv validate` checks against the updated envelope schema: ambient `Progress` (both empty) validates, session-scoped `Progress` (both non-empty) validates, mixed `Progress` (one empty, one non-empty) is correctly rejected; existing `Signal`/`SessionStart` positive and negative fixtures unaffected.

Closes #87
Closes #88

https://claude.ai/code/session_01HWcTpkEBdYBMDt7FjDbyJi