### PR TITLE
rfcs: reserve the policy.std namespace and define three governance profiles (#55)

### DIFF
--- a/registries/policies.md
+++ b/registries/policies.md
@@ -14,21 +14,18 @@ Example:
 
 ## Reserved Policies
 
-| Policy ID | Mode | Description | Status | Reference |
-|-----------|------|-------------|--------|-----------|
-| `policy.default` | `*` | Default policy — no additional governance constraints beyond the mode's built-in rules | permanent | [RFC-MACP-0012](../rfcs/RFC-MACP-0012-policy.md) |
+| Policy ID | Mode | Description | Provision | Reference |
+|-----------|------|-------------|-----------|-----------|
+| `policy.default` | `*` | Default policy — no additional governance constraints beyond the mode's built-in rules | required | [RFC-MACP-0012 §5.1](../rfcs/RFC-MACP-0012-policy.md) |
+| `policy.std.majority` | `macp.mode.decision.v1` | Simple majority — at least half of the decisive votes approve, minimum 1 voter | optional | [RFC-MACP-0012 §5.2](../rfcs/RFC-MACP-0012-policy.md) |
+| `policy.std.supermajority` | `macp.mode.decision.v1` | Two-thirds supermajority, minimum 2 voters | optional | [RFC-MACP-0012 §5.2](../rfcs/RFC-MACP-0012-policy.md) |
+| `policy.std.unanimous` | `macp.mode.decision.v1` | Every declared participant approves and no reject is cast | optional | [RFC-MACP-0012 §5.2](../rfcs/RFC-MACP-0012-policy.md) |
 
 The `policy.default` identifier is reserved and MUST NOT be registered or unregistered. It is pre-registered in every conformant runtime.
 
-## Well-Known Policies
+The whole `policy.std.` namespace is reserved. A runtime MAY pre-register any subset of the profiles above, including none of them — reservation is a collision guarantee, not a provisioning requirement. A runtime that does provide one MUST use the canonical rules in RFC-MACP-0012 §5.2 verbatim, and a `SessionStart` naming a `policy.std.` identifier the runtime does not provide is rejected with `UNKNOWN_POLICY_VERSION`. Identifiers under `policy.std.` not listed above are reserved but unassigned.
 
-Well-known policies are not reserved but are recommended for common governance patterns:
-
-| Policy ID | Mode | Description | Status |
-|-----------|------|-------------|--------|
-| `policy.majority` | `macp.mode.decision.v1` | Simple majority vote (>50%) with no quorum requirement | recommended |
-| `policy.supermajority` | `macp.mode.decision.v1` | Two-thirds supermajority with minimum 2-voter quorum | recommended |
-| `policy.unanimous` | `macp.mode.decision.v1` | All participants must vote approve; any reject blocks | recommended |
+Short unnamespaced identifiers such as `policy.majority` are **not** reserved and remain available to deployments. Deployments SHOULD still use their own namespace (`policy.{org}.{name}`) so that later additions under `policy.std.` cannot collide with local rules.
 
 ## Registration
 

--- a/rfcs/RFC-MACP-0012-policy.md
+++ b/rfcs/RFC-MACP-0012-policy.md
@@ -43,7 +43,20 @@ Examples:
 
 ### 2.2 Reserved Namespace
 
-The `policy.default` identifier is reserved. Runtimes MUST NOT allow registration of a policy with this identifier; it is always pre-registered.
+Two reservations exist.
+
+**`policy.default`.** The `policy.default` identifier is reserved. Runtimes MUST NOT allow registration of a policy with this identifier; it is always pre-registered (Section 5.1). It predates the `policy.{namespace}.{name}` convention of Section 2.1 and retains its two-segment form.
+
+**`policy.std.`.** Every identifier beginning with `policy.std.` is reserved for the built-in governance profiles published in this specification. Runtimes MUST NOT allow registration of a policy whose `policy_id` begins with `policy.std.` — via `RegisterPolicy` or via any implementation-defined loading path — unless the descriptor is one of the canonical definitions in Section 5.2. A registration that violates this MUST be rejected with `INVALID_POLICY_DEFINITION`.
+
+Reservation is a **collision guarantee, not a provisioning requirement**:
+
+- A runtime MAY pre-register any subset of the profiles defined in Section 5.2, including none of them. `policy.default` remains the only policy a runtime MUST provide.
+- If a runtime provides a policy under a reserved `policy.std.` identifier, that policy MUST be semantically equal to the canonical definition for that identifier: every rule parameter — whether spelled out explicitly or left to its JSON Schema default — MUST resolve to the value Section 5.2 gives, and `mode` and `schema_version` MUST match. A runtime MUST NOT ship different rules under a reserved identifier.
+- A `SessionStart` naming a `policy.std.` identifier the runtime does not provide is an unknown policy and MUST be rejected with `UNKNOWN_POLICY_VERSION` per Section 6.1. Clients MUST NOT assume that a reserved identifier resolves on every runtime; `ListPolicies` reports what is actually available.
+- Identifiers under `policy.std.` that this specification has not assigned are reserved but unassigned: they MUST NOT be registered and MUST NOT resolve.
+
+Identifiers outside these two reservations — including short unnamespaced forms such as `policy.majority` — are **not** reserved and remain available to deployments. Deployments SHOULD nevertheless use their own namespace (`policy.{org}.{name}`) so that later additions under `policy.std.` cannot collide with local governance rules.
 
 ### 2.3 Immutability
 
@@ -85,11 +98,19 @@ Canonical schema: `schemas/json/policy/decision-rules.schema.json`
 **Voting algorithms:**
 
 - `none` — no voting constraint enforced (mode's built-in logic applies)
-- `majority` — more than 50% of cast votes must approve
-- `supermajority` — at least `threshold` fraction of cast votes must approve
-- `unanimous` — all cast votes must approve
-- `weighted` — weighted votes using `weights` map; `threshold` applies to weighted sum
-- `plurality` — proposal with the most approve votes wins; no threshold
+- `majority` — at least `threshold` (default `0.5`) of the decisive votes approve
+- `supermajority` — at least `threshold` of the decisive votes approve; the schema constrains `threshold` to be greater than `0.5`
+- `unanimous` — every declared participant has cast an approve vote and no reject vote was cast; `threshold` is not used
+- `weighted` — weighted votes using `weights` map; `threshold` applies to the weighted approve share
+- `plurality` — more approve votes than reject votes; a tie fails; no threshold
+
+**Denominator.** For the ratio-based algorithms (`majority`, `supermajority`, `weighted`) the denominator is the **decisive** votes — those cast as approve or reject. Abstentions are excluded and neither help nor hinder the ratio (RFC-MACP-0004).
+
+**Inclusive comparison.** Every threshold comparison in this section is inclusive (`ratio >= threshold`). With `majority` at its default `threshold` of `0.5`, an even split therefore approves. A rule that requires strictly more approvals than rejections is `plurality`, not `majority` with `threshold: 0.5`. `unanimous` is stricter than "all decisive votes approve": a declared participant who has not voted blocks it.
+
+**`voting.quorum` is inert on its own.** `voting.quorum` states the participation bar but does not itself gate a commitment; it is applied only when `commitment.require_vote_quorum` is `true`. A policy that sets `voting.quorum` without `require_vote_quorum` imposes no participation requirement.
+
+**No decisive votes.** With any algorithm other than `none`, if no decisive vote has been cast the algorithm produces no result — it neither passes nor fails. Whether that blocks the commitment is then governed entirely by `commitment.require_vote_quorum`: with it `false`, a positive commitment is **not** blocked by the absence of votes, even under `majority` or `unanimous`. A policy that intends its voting algorithm to be binding therefore MUST set `commitment.require_vote_quorum` to `true`. A negative commitment is always blocked in this case, because a decline must be backed by at least one explicit reject (see RFC-MACP-0007 §6.2).
 
 **Quorum:**
 
@@ -151,7 +172,9 @@ Canonical schema: `schemas/json/policy/handoff-rules.schema.json`
 
 Extension modes registered via `RegisterExtMode` MAY define custom rule schemas. The runtime SHOULD validate custom rules against the mode's declared policy schema if one exists. Extension modes without a declared policy schema accept any valid JSON as rules.
 
-## 5. Default Policy
+## 5. Built-in Policies
+
+### 5.1 Default Policy
 
 Every conformant runtime MUST pre-register the following default policy:
 
@@ -168,6 +191,88 @@ Every conformant runtime MUST pre-register the following default policy:
 The default policy applies no additional governance constraints beyond base mode validation. Mode-specific default behaviors (e.g., Decision Mode's default voting algorithm, Quorum Mode's default abstention handling) are defined by each mode's base validation rules in their respective RFCs, not by the default policy.
 
 When `policy_version` in `SessionStartPayload` is empty or equals `policy.default`, the runtime MUST apply this default. The default policy sets all rule parameters to permissive values such that the mode's built-in validation is the only constraint applied. It does not disable mode validation — it simply adds no governance restrictions on top of it.
+
+An empty `rules` object and a `rules` object that spells out every parameter at its JSON Schema default are the same policy. A runtime MAY pre-register either form.
+
+### 5.2 Reserved Governance Profiles
+
+Three common governance profiles are assigned reserved identifiers under the `policy.std.` namespace of Section 2.2. Unlike `policy.default`, they are **optional**: a runtime MAY pre-register any subset of them, and one that pre-registers none of them remains conformant. What the reservation guarantees is that these identifiers cannot be claimed by a user registration, so an identifier that does resolve resolves to the rules below on every runtime.
+
+All three target `macp.mode.decision.v1` and declare `schema_version: 1`; they use only schema-version-1 rule fields. They are Decision Mode profiles specifically because a descriptor binds exactly one `mode` (Section 3) and because Decision Mode is the only standard mode whose rule schema can express these three bars exactly — see the note at the end of this section.
+
+| Policy ID | Mode | Governance bar |
+|-----------|------|----------------|
+| `policy.std.majority` | `macp.mode.decision.v1` | At least half of the decisive votes approve |
+| `policy.std.supermajority` | `macp.mode.decision.v1` | At least two-thirds of the decisive votes approve, with at least two voters |
+| `policy.std.unanimous` | `macp.mode.decision.v1` | Every declared participant has approved and no reject was cast |
+
+Each profile sets `commitment.require_vote_quorum` to `true`. Without it the voting algorithm is not binding on a positive commitment when no vote has been cast (see the "No decisive votes" note in Section 4.1), which would make each of these profiles vacuous in exactly the case they exist to govern.
+
+#### `policy.std.majority`
+
+```json
+{
+  "policy_id": "policy.std.majority",
+  "mode": "macp.mode.decision.v1",
+  "schema_version": 1,
+  "description": "Simple majority — at least half of the decisive votes approve",
+  "rules": {
+    "voting": {
+      "algorithm": "majority",
+      "threshold": 0.5,
+      "quorum": { "type": "count", "value": 1 }
+    },
+    "commitment": { "require_vote_quorum": true }
+  }
+}
+```
+
+A positive commitment is allowed when at least one participant has voted and `approve / (approve + reject) >= 0.5`. The comparison is inclusive per Section 4.1, so an even split approves; a profile in which a tie fails is `plurality`, which this specification does not reserve.
+
+#### `policy.std.supermajority`
+
+```json
+{
+  "policy_id": "policy.std.supermajority",
+  "mode": "macp.mode.decision.v1",
+  "schema_version": 1,
+  "description": "Two-thirds supermajority with a minimum of two voters",
+  "rules": {
+    "voting": {
+      "algorithm": "supermajority",
+      "threshold": 0.6666666666666666,
+      "quorum": { "type": "count", "value": 2 }
+    },
+    "commitment": { "require_vote_quorum": true }
+  }
+}
+```
+
+A positive commitment is allowed when at least two participants have voted and `approve / (approve + reject) >= threshold`.
+
+**Determinism note:** two-thirds is not exactly representable in binary floating point. The literal `0.6666666666666666` is the IEEE-754 binary64 value nearest to two-thirds, and it is the same binary64 value that `2 / 3` produces under binary64 division. Implementations MUST evaluate this comparison in binary64 so that the intended outcomes hold: 2 of 3, 4 of 6, 20 of 30, and 67 of 100 approvals pass, and 66 of 100 does not. An implementation using exact decimal or rational arithmetic would compute `2/3 < 0.6666666666666666` and reject 2 of 3, which is why the arithmetic is pinned rather than left implicit under Section 6.3.
+
+#### `policy.std.unanimous`
+
+```json
+{
+  "policy_id": "policy.std.unanimous",
+  "mode": "macp.mode.decision.v1",
+  "schema_version": 1,
+  "description": "Unanimous — every declared participant approves and no reject is cast",
+  "rules": {
+    "voting": {
+      "algorithm": "unanimous",
+      "quorum": { "type": "count", "value": 1 }
+    },
+    "commitment": { "require_vote_quorum": true }
+  }
+}
+```
+
+A positive commitment is allowed when every identifier in the session's declared `participants` has cast an approve vote and no reject vote exists. Per Section 4.1 this is stricter than "all decisive votes approve": a participant who has not voted blocks the commitment, and `threshold` is not consulted. The `quorum` entry only keeps the algorithm binding; the all-participants requirement comes from the algorithm itself.
+
+**Why Decision Mode only.** "Majority", "supermajority", and "unanimous" are meaningful in Quorum Mode as well, but Quorum Mode expresses its bar through `threshold` (Section 4.2), whose `n_of_m` type is an absolute approval count and whose `percentage` type is an integer 0–100 rounded up against the declared participant count. An absolute count cannot express a bar that scales with participants, and an integer percentage cannot express two-thirds or a strict majority exactly at every participant count: `67` requires 3 of 3 rather than 2 of 3, and `51` requires 102 of 200 rather than 101. `100` does express unanimity exactly, but reserving a single Quorum Mode profile whose siblings cannot exist would be worse than reserving none. Quorum Mode profiles are therefore left unassigned; they need an exact-fraction threshold type, which is a schema addition and out of scope here.
 
 ## 6. Evaluation Semantics
 
@@ -229,6 +334,7 @@ Unlike `WatchModeRegistry` (which returns a lightweight `RegistryChanged` notifi
 Registration constraints:
 
 - `policy.default` MUST NOT be registered or unregistered (it is built-in).
+- A `policy_id` in the reserved `policy.std.` namespace MUST NOT be registered unless the descriptor is the canonical definition for that identifier (Section 2.2), and a pre-registered `policy.std.` policy MUST NOT be unregistered.
 - `policy_id` MUST be unique; re-registration of an existing ID MUST fail.
 - `rules` MUST validate against the target mode's rule JSON Schema if a schema exists.
 - Unregistering a policy does not affect sessions that have already resolved it.

--- a/schemas/json/policy/decision-rules.schema.json
+++ b/schemas/json/policy/decision-rules.schema.json
@@ -24,7 +24,7 @@
         },
         "quorum": {
           "type": "object",
-          "description": "Minimum participation required before votes are counted.",
+          "description": "Minimum participation bar. Applied only when commitment.require_vote_quorum is true; on its own this object gates nothing. See RFC-MACP-0012 Section 4.1.",
           "properties": {
             "type": {
               "type": "string",
@@ -35,7 +35,7 @@
               "type": "number",
               "minimum": 0,
               "default": 0,
-              "description": "Minimum count or percentage (0-1) of participants that must vote."
+              "description": "Minimum number of participants that must vote ('count'), or the minimum share of declared participants that must vote as a percentage in 0-100 ('percentage')."
             }
           }
         },


### PR DESCRIPTION
Closes #55 — but **please do not merge this yet.** It implements a naming decision that is yours to ratify (details below), and a second, smaller one.

## ⚠️ Held for ratification: which shape?

Issue #55 offered a fork: reserve `policy.majority` / `policy.supermajority` / `policy.unanimous` as **flat names** (a), or reserve a **`policy.std.*`-style namespace** (b).

**This PR implements (b).** Switching to (a) is a one-line change to the reserved-prefix paragraph in §2.2 plus the three identifiers in §5.2 and `registries/policies.md` — no rule definition changes.

Why (b):

1. **§2.1 already states the convention** as `policy.{namespace}.{name}`. A flat `policy.majority` does not satisfy it; `policy.std.majority` does exactly, with `std` as the namespace. (`policy.default` is grandfathered explicitly — it also hard-codes into the §6.1 resolution rule, so it is genuinely different in kind.)
2. **This program reserves by prefix, not by name.** RFC-0002 reserves the whole `macp.mode.*` namespace and directs runtime-shipped built-ins to `ext.*`. Reserving three individual names means an RFC amendment for every future built-in.
3. **A descriptor binds exactly one `mode` (§3).** "Majority" is meaningful in Decision *and* Quorum Mode but needs different rule fields, so one flat `policy.majority` can never serve both. A namespace leaves room for mode-scoped siblings without re-litigating the reservation.
4. **The rename is free today, and only today.** `grep` across `macp-runtime`, `macp-sdk-python` and `macp-sdk-typescript` finds `policy.majority`/`supermajority`/`unanimous` **only in prose** — `registries/policies.md`, `macp-runtime/plans/BUILD_STATUS.md`, `macp-runtime/plans/defer/follow_ons.md`. No implementation ships them as identifiers. Reserve the flat names now and that free rename is gone.
5. It keeps the short, attractive names available to deployments — which is the collision the issue wants to avoid, solved by moving the built-ins out of the space users reach for rather than taking it from them.

Argument for (a), for the record: `policy.default` is flat, so reserved identifiers end up in two shapes, and the flat names are already published in `registries/policies.md` and referenced by macp-runtime's improvement plan §4.2.

## ⚠️ Second thing to ratify: §4.1 says things no implementation does

I could not write canonical rules without first pinning what `majority` and `unanimous` mean, and the RFC and the only evaluator in the ecosystem disagreed. **§4.1 is corrected toward the implementation**, deliberately — tightening it the other way would have made the reference runtime instantly non-conforming.

| §4.1 said | `crates/macp-policy/src/evaluator.rs` does |
|---|---|
| `majority` — "more than 50% of cast votes must approve" | `ratio >= threshold`, threshold default `0.5` → **an even split approves** |
| `unanimous` — "all cast votes must approve" | every **declared participant** must have cast APPROVE → **a silent participant blocks** (strictly stronger) |
| `plurality` — "proposal with the most approve votes wins" | aggregates across proposals, compares total approve vs total reject; tie fails |
| `voting.quorum` reads as a standalone gate | consulted **only** when `commitment.require_vote_quorum` is `true` |

Plus one that was documented nowhere: with `require_vote_quorum` false, **a positive commitment is allowed with zero votes cast under any algorithm** (the `NoVotes` branch adds no deny reason). That is why all three canonical profiles set `require_vote_quorum: true` — without it a "unanimous" policy lets the initiator commit unopposed with no votes at all.

Both SDKs' `majority_winner()` projection helpers use strict `> 0.5`, i.e. the old §4.1 reading — but both files carry an explicit "no policy enforcement" disclaimer, so they are not evaluators and this does not put them in conflict with the corrected text.

## What is reserved

`policy.std.` as a prefix, plus the existing `policy.default`. Three profiles assigned, all `macp.mode.decision.v1`, all `schema_version: 1`:

| Policy ID | Rules (abbreviated) |
|---|---|
| `policy.std.majority` | `majority` @ `0.5`, quorum count 1, `require_vote_quorum` |
| `policy.std.supermajority` | `supermajority` @ `0.6666666666666666`, quorum count 2, `require_vote_quorum` |
| `policy.std.unanimous` | `unanimous`, quorum count 1, `require_vote_quorum` |

**Conformance impact: none.** Per the issue's own motivation (collision-avoidance), reservation is a *collision guarantee, not a provisioning requirement*:

- `policy.default` remains the **only** policy a runtime MUST pre-register. The three profiles are **MAY**.
- A runtime that *does* provide one MUST use the canonical rules; it MUST NOT ship different rules under a reserved id.
- A `SessionStart` naming a profile the runtime does not provide → `UNKNOWN_POLICY_VERSION` (§6.1). Clients must not assume availability; `ListPolicies` reports the truth.
- Registering into the reserved prefix → `INVALID_POLICY_DEFINITION`.

No implementation is non-conforming under this text today, and none needs a release to become conforming.

**Decision Mode only, deliberately.** Quorum Mode's `threshold` is an absolute count (`n_of_m`) or an integer percentage rounded up against the participant count. An absolute count cannot scale with participants, and an integer percentage cannot express these bars exactly at every N: `67` demands 3-of-3 rather than 2-of-3; `51` demands 102-of-200 rather than 101. Only `100` (unanimity) is exact. Reserving one Quorum profile whose siblings cannot exist would be worse than reserving none — a faithful Quorum majority needs an exact-fraction threshold type, which is a schema addition and out of scope. **This is the "a field that doesn't exist" finding**, and it is the reason the scope is one mode.

**Determinism note on two-thirds.** Not representable in binary floating point. `0.6666666666666666` is pinned as the binary64 value nearest it, and §5.2 requires binary64 evaluation. Verified numerically: 2/3, 4/6, 6/9, 20/30 and 67/100 pass; 66/100 fails. Under exact decimal/rational arithmetic `2/3 < 0.6666666666666666` and 2-of-3 would be rejected — hence the explicit pin rather than leaving it implicit under §6.3.

## Also in this diff

Two description-string corrections in `schemas/json/policy/decision-rules.schema.json` (no semantics, no `$ref` shape change): the `quorum` object's standalone-gate wording, and `quorum.value`, which said percentages are `0-1` while the evaluator computes `voters/participants*100 >= value` and the TypeScript SDK documents `0-100`.

## Validation — actual output

Canonical rules and descriptors against the real schemas (`ajv`, draft2020):

```
--- majority       : rules vs decision-rules.schema.json              valid
--- majority       : descriptor vs macp-policy-descriptor.schema.json valid
--- supermajority  : rules vs decision-rules.schema.json              valid
--- supermajority  : descriptor vs macp-policy-descriptor.schema.json valid
--- unanimous      : rules vs decision-rules.schema.json              valid
--- unanimous      : descriptor vs macp-policy-descriptor.schema.json valid
```

Negative control, proving the `supermajority` branch is live rather than vacuously passing:

```
$ ajv validate -s schemas/json/policy/decision-rules.schema.json -d neg_supermajority.json --spec=draft2020 --strict=false
  invalid
  [ { instancePath: '/voting/threshold',
      schemaPath: '#/allOf/1/then/properties/voting/properties/threshold/exclusiveMinimum',
      keyword: 'exclusiveMinimum', params: { comparison: '>', limit: 0.5 },
      message: 'must be > 0.5' } ]
```

Repo checks:

```
$ python3 schemas/conformance/lint_fixtures.py
...
All 17 conformance fixtures are internally consistent.

$ bash scripts/check-indexes.sh
-- RFCs (rfcs/RFC-MACP-*-*.md) --
  [OK] 13 RFC file(s) checked against 4 indexes
-- Registries (registries/*.md) --
  [OK] 7 registry file(s) checked against 2 indexes
-- Conformance fixtures (schemas/conformance/*.json) --
  [OK] 17 fixture file(s) checked against 1 index
[OK] All indexes in sync (37 files checked)

$ bash scripts/validate-json.sh
[OK] All 42/42 JSON files validated
```

Note `validate-json.sh` does **not** validate per-mode policy rule schemas at all — the six validations above were run separately by hand. Wiring them into the script is a reasonable follow-up.

## Not done, on purpose

- **`schemas/conformance/` untouched.** No fixture exercises these profiles. Adding one would fan out to three vendoring repos with bidirectional CI, so it should be a separate issue if wanted.
- **No `examples/` file.** The canonical JSON would then live in two places and drift; `validate-json.sh` only checks descriptor shape anyway, not the rules.
- **Executable proof against the reference evaluator.** I wrote a harness exercising all three profiles against `evaluate_decision_commitment_outcome` (tie approves, silent participant blocks, zero-votes denied, 66-vs-67 of 100), but `cargo` could not write dep-files in this sandbox, so it did **not** run. The semantics above come from reading `evaluator.rs` directly plus numeric verification of the float comparisons. Worth landing that harness in macp-runtime alongside the built-ins.

## Conflict check

Branched from `origin/main` (includes #85, #86, #89). Touches only RFC-MACP-0012, `registries/policies.md`, and the decision-rules schema — no overlap with open PR #91 (RFC-MACP-0001 + envelope schema).
