### PR TITLE
test(conformance): pin the objection_handling veto and finalize_decline arms (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ MACP/
       decision_happy_path.json
       decision_negative_outcome.json
       decision_reject_paths.json
+      decision_critical_objection_veto.json
+      decision_critical_objection_finalize_decline.json
       proposal_happy_path.json
       proposal_negative_outcome.json
       proposal_reject_paths.json

--- a/schemas/conformance/decision_critical_objection_finalize_decline.json
+++ b/schemas/conformance/decision_critical_objection_finalize_decline.json
@@ -1,0 +1,106 @@
+{
+  "description": "Decision mode: critical_objection_action 'finalize_decline' blocks a positive commitment but authorizes a negative one, resolving the session as a decline.",
+  "mode": "macp.mode.decision.v1",
+  "initiator": "agent://orchestrator",
+  "participants": [
+    "agent://orchestrator",
+    "agent://a",
+    "agent://b"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy": {
+    "_comment": "RFC-MACP-0012 Section 4.1 (:102): 'finalize_decline' finalizes the session as a negative outcome. voting.algorithm is 'none' deliberately — with any vote-based algorithm a decline additionally requires an explicit reject vote, which would confound this fixture's discriminator with the vote-gated decline already pinned by decision_negative_outcome.json.",
+    "policy_id": "policy.decision.critical-veto-decline",
+    "mode": "macp.mode.decision.v1",
+    "schema_version": 2,
+    "description": "Initiator-driven commitment where a critical-severity objection finalizes the session as a decline.",
+    "rules": {
+      "voting": { "algorithm": "none" },
+      "objection_handling": {
+        "critical_severity_vetoes": true,
+        "critical_objection_action": "finalize_decline"
+      },
+      "commitment": { "authority": "initiator_only" }
+    }
+  },
+  "policy_version": "policy.decision.critical-veto-decline",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://orchestrator",
+      "message_type": "Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "option": "deploy",
+        "rationale": "ready",
+        "supporting_data": []
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://b",
+      "message_type": "Objection",
+      "payload_type": "macp.modes.decision.v1.ObjectionPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "reason": "unresolved data-retention finding",
+        "severity": "critical"
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "Under 'finalize_decline' the veto still blocks the POSITIVE direction — this is the arm shared with the default 'deny' action.",
+      "sender": "agent://orchestrator",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "outcome_positive": true,
+        "action": "decision.approved",
+        "authority_scope": "test",
+        "reason": "attempt to commit over a standing critical objection",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.decision.critical-veto-decline",
+        "configuration_version": "cfg-1"
+      },
+      "expect": "reject",
+      "expected_error_code": "POLICY_DENIED"
+    },
+    {
+      "_comment": "This is the discriminator. Under the default 'deny' action this same message is rejected with POLICY_DENIED; under 'finalize_decline' the veto authorizes the decline and the session resolves negatively. No vote was ever cast, so nothing but critical_objection_action can produce this outcome.",
+      "sender": "agent://orchestrator",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c2",
+        "outcome_positive": false,
+        "action": "decision.rejected",
+        "authority_scope": "test",
+        "reason": "critical objection finalized as a decline",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.decision.critical-veto-decline",
+        "configuration_version": "cfg-1"
+      },
+      "expect": "accept"
+    }
+  ],
+  "expected_final_state": "Resolved",
+  "expect_resolution_present": true,
+  "expected_resolution": {
+    "action": "decision.rejected",
+    "mode_version": "1.0.0",
+    "configuration_version": "cfg-1",
+    "outcome_positive": false
+  },
+  "expected_mode_state": {
+    "phase": "Committed",
+    "proposals": {
+      "p1": {
+        "proposal_id": "p1",
+        "sender": "agent://orchestrator"
+      }
+    }
+  }
+}

--- a/schemas/conformance/decision_critical_objection_veto.json
+++ b/schemas/conformance/decision_critical_objection_veto.json
@@ -1,0 +1,119 @@
+{
+  "description": "Decision mode: a critical-severity Objection vetoes commitment when objection_handling.critical_severity_vetoes is true, overriding an otherwise-passing approval majority.",
+  "mode": "macp.mode.decision.v1",
+  "initiator": "agent://orchestrator",
+  "participants": [
+    "agent://orchestrator",
+    "agent://a",
+    "agent://b"
+  ],
+  "mode_version": "1.0.0",
+  "configuration_version": "cfg-1",
+  "policy": {
+    "_comment": "RFC-MACP-0012 Section 4.1 (:102): critical_objection_action defaults to 'deny'. Left unset here deliberately so this fixture pins the DEFAULT arm.",
+    "policy_id": "policy.decision.critical-veto",
+    "mode": "macp.mode.decision.v1",
+    "schema_version": 2,
+    "description": "Majority vote, initiator-only commitment, with critical-severity objections vetoing commitment.",
+    "rules": {
+      "voting": {
+        "algorithm": "majority"
+      },
+      "objection_handling": {
+        "critical_severity_vetoes": true
+      },
+      "commitment": {
+        "authority": "initiator_only"
+      }
+    }
+  },
+  "policy_version": "policy.decision.critical-veto",
+  "ttl_ms": 60000,
+  "messages": [
+    {
+      "sender": "agent://orchestrator",
+      "message_type": "Proposal",
+      "payload_type": "macp.modes.decision.v1.ProposalPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "option": "deploy",
+        "rationale": "ready",
+        "supporting_data": []
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "RFC-MACP-0007 Section 4 (:62-64): Objection carries an explicit severity; only 'critical' feeds the veto path of RFC-MACP-0012 objection_handling. It is placed before any Vote because the Decision mode only accepts Objection while the session is still deliberating -- once a Vote moves the phase on, a further Objection is rejected.",
+      "sender": "agent://b",
+      "message_type": "Objection",
+      "payload_type": "macp.modes.decision.v1.ObjectionPayload",
+      "payload": {
+        "proposal_id": "p1",
+        "reason": "deployment window overlaps a scheduled change freeze",
+        "severity": "critical"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://a",
+      "message_type": "Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
+      "payload": {
+        "proposal_id": "p1",
+        "vote": "APPROVE",
+        "reason": "looks good"
+      },
+      "expect": "accept"
+    },
+    {
+      "sender": "agent://b",
+      "message_type": "Vote",
+      "payload_type": "macp.modes.decision.v1.VotePayload",
+      "payload": {
+        "proposal_id": "p1",
+        "vote": "APPROVE",
+        "reason": "no blockers seen yet"
+      },
+      "expect": "accept"
+    },
+    {
+      "_comment": "The veto is decisive: both cast votes APPROVE, so the majority algorithm passes, yet the commitment is denied. That is what distinguishes critical_severity_vetoes=true from the default false -- decision_happy_path.json replays the same Proposal/critical-Objection/APPROVE-Vote shape under policy.default and commits successfully.",
+      "sender": "agent://orchestrator",
+      "message_type": "Commitment",
+      "payload_type": "macp.v1.CommitmentPayload",
+      "payload": {
+        "commitment_id": "c1",
+        "outcome_positive": true,
+        "action": "decision.approved",
+        "authority_scope": "test",
+        "reason": "attempt to commit over a standing critical objection",
+        "mode_version": "1.0.0",
+        "policy_version": "policy.decision.critical-veto",
+        "configuration_version": "cfg-1"
+      },
+      "expect": "reject",
+      "expected_error_code": "POLICY_DENIED"
+    }
+  ],
+  "expected_final_state": "Open",
+  "expect_resolution_present": false,
+  "expected_mode_state": {
+    "phase": "Voting",
+    "proposals": {
+      "p1": {
+        "proposal_id": "p1",
+        "sender": "agent://orchestrator"
+      }
+    },
+    "votes": {
+      "p1": {
+        "agent://a": {
+          "vote": "APPROVE"
+        },
+        "agent://b": {
+          "vote": "APPROVE"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #90.

`grep` over `schemas/conformance/` returned **zero** occurrences of `critical_severity_vetoes` or `critical_objection_action`. No fixture bound a decision policy with an `objection_handling` block and asserted the resulting commitment outcome. As #90 says, this was never a live divergence — the runtime and `macp-sdk-python` agree today — it was an *unpinned* agreement, with nothing in any of the four repos holding them there.

## Two fixtures

**`decision_critical_objection_veto.json`** pins the **default `deny`** arm (`critical_objection_action` is deliberately left unset, so the fixture pins the default rather than an explicit value). A `critical` Objection blocks a positive Commitment with `POLICY_DENIED` even though both cast votes are `APPROVE` and the `majority` algorithm passes. That framing is deliberate: the fixture fails if the veto ever stops overriding an otherwise-passing vote outcome, which a simpler no-votes transcript would not catch.

The Objection is ordered **before** the votes because Decision mode only accepts `Objection` while deliberating — `ensure_can_deliberate` requires `phase == Evaluation`, so an Objection after any Vote is rejected with `InvalidPayload`. `decision_happy_path.json` orders its Objection the same way for the same reason. I found this by writing the fixture the other way round first and having the runtime reject it.

**`decision_critical_objection_finalize_decline.json`** pins `critical_objection_action: "finalize_decline"` — the one arm with an outcome the default cannot produce. The veto blocks the positive Commitment but *authorizes* the negative one, resolving the session as a decline. No vote is ever cast, so nothing but `critical_objection_action` can produce that resolution.

`voting.algorithm` is `none` deliberately. Under any vote-based algorithm a decline additionally requires an explicit reject vote (the evaluator's `NoVotes` arm denies a negative commitment outright), which would confound this fixture's discriminator with the vote-gated decline already pinned by `decision_negative_outcome.json`.

## `hold` is deliberately not pinned

`hold` is **observationally identical to `deny`** in the reference runtime. Both arms push to `deny_reasons`, and `deny_reasons` always wins, so both yield `POLICY_DENIED` and leave the session open. They differ only in a human-readable reason string, and the fixture schema has no field to assert one.

This is worth flagging on its own: RFC-MACP-0012 §4.1 describes the three arms as `deny` (reject the commitment), `finalize_decline` (finalize as a negative outcome), and `hold` (leave the session open) — but a rejected commitment already leaves the session open, so the text implies a distinction the implementation does not make. Pinning `hold` would need either a schema addition (asserting on the denial reason) or a semantic decision about what `hold` should do differently. Neither belongs in a fixture PR; I have written this up on #90 rather than silently omitting the arm.

## Verified in all three harnesses

Not just "the files lint" — I confirmed each harness actually *discovers and exercises* them, since a vendored fixture that no test registers is silently inert.

| Harness | Result |
|---|---|
| `macp-runtime` conformance oracle | **20 passed, 0 failed** — the only harness that evaluates policy, so the semantics above are asserted here |
| `macp-sdk-typescript` | discovered dynamically; 4 assertions each (projection replay, duplicate-ballot, format guard, reject-path well-formedness) |
| `macp-sdk-python` | discovered dynamically; 4 assertions each (projection replay, payload-type, vendored-schema validation, reject-path) |

`python schemas/conformance/lint_fixtures.py` → all 19 fixtures consistent.

## Sequencing

Merging this turns the fixture-oracle job red in all three consuming repos until each vendors the new files. Vendoring PRs will be opened against this branch's content and confirmed to fail *only* their fixture-oracle job before this merges, per the coordinated fan-out protocol used for #89.